### PR TITLE
django-error-email-dedup extension added

### DIFF
--- a/backend/common/logger/__init__.py
+++ b/backend/common/logger/__init__.py
@@ -1,45 +1,7 @@
-import traceback
+"""Compatibility wrapper for the external mail dedup extension."""
 
-from django.core import mail
-from django.utils.log import AdminEmailHandler
-from django.views.debug import ExceptionReporter, get_exception_reporter_filter
+from django_error_mail_dedup.handlers import DedupAdminEmailHandler
 
 
-class CustomAdminEmailHandler(AdminEmailHandler):
-    def __init__(self, include_html=True):
-        AdminEmailHandler.__init__(self)
-        self.include_html = include_html
-
-    def emit(self, record):
-        try:
-            request = record.request
-            subject = "{} {} (IP {}) | {}".format(
-                record.levelname,
-                record.status_code,
-                (request.META.get("REMOTE_ADDR")),
-                record.getMessage(),
-            )
-            reporter_filter = get_exception_reporter_filter(request)
-            request_repr = reporter_filter.get_request_repr(request)
-
-        except Exception:
-            subject = f"{record.levelname}: {record.getMessage()}"
-            request = None
-            request_repr = "Request repr() is unavailable"
-
-        subject = self.format_subject(subject)
-
-        if record.exc_info:
-            exc_info = record.exc_info
-            stack_trace = "\n".join(traceback.format_exception(*record.exc_info))
-        else:
-            exc_info = (None, record.getMessage(), None)
-            stack_trace = "No stack trace is available"
-
-        message = f"{stack_trace}\n\n{request_repr}"
-        reporter = ExceptionReporter(request, is_email=True, *exc_info)
-        html_message = self.include_html and reporter.get_traceback_html() or None
-
-        mail.mail_admins(
-            subject, message, fail_silently=True, html_message=html_message
-        )
+class CustomAdminEmailHandler(DedupAdminEmailHandler):
+    """Backwards-compatible alias for legacy import path."""

--- a/backend/requirements/3.10/base.txt
+++ b/backend/requirements/3.10/base.txt
@@ -12,11 +12,12 @@ diff-match-patch==20241021
     # via django-import-export
 dj-database-url==3.1.2
     # via -r backend/requirements/base.in
-django==5.2.12
+django==5.2.13
     # via
     #   -r backend/requirements/base.in
     #   dj-database-url
     #   django-authtools
+    #   django-error-mail-dedup
     #   django-extensions
     #   django-import-export
     #   django-linear-migrations
@@ -26,6 +27,8 @@ django==5.2.12
 django-admin-list-filter-dropdown==1.0.3
     # via -r backend/requirements/base.in
 django-authtools @ git+https://github.com/adRn-s/django-authtools@a3284c976719bd26f085fdac9951009acda804dc
+    # via -r backend/requirements/base.in
+django-error-mail-dedup @ git+https://github.com/adRn-s/django-error-mail-dedup@2e9be2bb1056ca6ed7a5dc606af38e3c9d594482
     # via -r backend/requirements/base.in
 django-extensions==4.1
     # via -r backend/requirements/base.in

--- a/backend/requirements/3.10/dev.txt
+++ b/backend/requirements/3.10/dev.txt
@@ -20,9 +20,9 @@ attrs==26.1.0
     #   -c backend/requirements/3.10/base.txt
     #   jsonschema
     #   referencing
-boto3==1.42.83
+boto3==1.42.86
     # via -r backend/requirements/dev.in
-botocore==1.42.83
+botocore==1.42.86
     # via
     #   boto3
     #   s3transfer
@@ -43,7 +43,7 @@ contourpy==1.3.2 ; python_full_version < '3.11'
     # via matplotlib
 contourpy==1.3.3 ; python_full_version >= '3.11'
     # via matplotlib
-cryptography==46.0.6
+cryptography==46.0.7
     # via
     #   django-cryptography-django5
     #   django-sql-explorer
@@ -67,7 +67,7 @@ dj-database-url==3.1.2
     # via
     #   -c backend/requirements/3.10/base.txt
     #   -r backend/requirements/base.in
-django==5.2.12
+django==5.2.13
     # via
     #   -c backend/requirements/3.10/base.txt
     #   -r backend/requirements/base.in
@@ -77,6 +77,7 @@ django==5.2.12
     #   django-cors-headers
     #   django-cryptography-django5
     #   django-debug-toolbar
+    #   django-error-mail-dedup
     #   django-extensions
     #   django-import-export
     #   django-linear-migrations
@@ -102,6 +103,10 @@ django-cryptography-django5==2.2
     # via django-sql-explorer
 django-debug-toolbar==6.3.0
     # via -r backend/requirements/dev.in
+django-error-mail-dedup @ git+https://github.com/adRn-s/django-error-mail-dedup@2e9be2bb1056ca6ed7a5dc606af38e3c9d594482
+    # via
+    #   -c backend/requirements/3.10/base.txt
+    #   -r backend/requirements/base.in
 django-extensions==4.1
     # via
     #   -c backend/requirements/3.10/base.txt
@@ -231,7 +236,7 @@ numpy==2.4.4 ; python_full_version >= '3.12'
     #   contourpy
     #   matplotlib
     #   pandas
-openai==2.30.0
+openai==2.31.0
     # via -r backend/requirements/dev.in
 openpyxl==3.1.5
     # via

--- a/backend/requirements/3.10/testing.txt
+++ b/backend/requirements/3.10/testing.txt
@@ -27,11 +27,11 @@ attrs==26.1.0
     #   -c backend/requirements/3.10/dev.txt
     #   jsonschema
     #   referencing
-boto3==1.42.83
+boto3==1.42.86
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   -r backend/requirements/dev.in
-botocore==1.42.83
+botocore==1.42.86
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   boto3
@@ -66,7 +66,7 @@ contourpy==1.3.3 ; python_full_version >= '3.11'
     #   matplotlib
 coverage==7.13.5
     # via pytest-cov
-cryptography==46.0.6
+cryptography==46.0.7
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   django-cryptography-django5
@@ -96,7 +96,7 @@ dj-database-url==3.1.2
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   -r backend/requirements/base.in
-django==5.2.12
+django==5.2.13
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   -r backend/requirements/base.in
@@ -106,6 +106,7 @@ django==5.2.12
     #   django-cors-headers
     #   django-cryptography-django5
     #   django-debug-toolbar
+    #   django-error-mail-dedup
     #   django-extensions
     #   django-import-export
     #   django-linear-migrations
@@ -139,6 +140,10 @@ django-debug-toolbar==6.3.0
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   -r backend/requirements/dev.in
+django-error-mail-dedup @ git+https://github.com/adRn-s/django-error-mail-dedup@2e9be2bb1056ca6ed7a5dc606af38e3c9d594482
+    # via
+    #   -c backend/requirements/3.10/dev.txt
+    #   -r backend/requirements/base.in
 django-extensions==4.1
     # via
     #   -c backend/requirements/3.10/dev.txt
@@ -205,7 +210,7 @@ fpdf2==2.8.7
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   -r backend/requirements/base.in
-greenlet==3.3.2
+greenlet==3.4.0
     # via playwright
 gunicorn==25.3.0
     # via
@@ -318,7 +323,7 @@ numpy==2.4.4 ; python_full_version >= '3.12'
     #   contourpy
     #   matplotlib
     #   pandas
-openai==2.30.0
+openai==2.31.0
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   -r backend/requirements/dev.in
@@ -402,7 +407,7 @@ pyparsing==3.3.2
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   matplotlib
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   pytest-base-url
     #   pytest-cov

--- a/backend/requirements/3.11/base.txt
+++ b/backend/requirements/3.11/base.txt
@@ -12,11 +12,12 @@ diff-match-patch==20241021
     # via django-import-export
 dj-database-url==3.1.2
     # via -r backend/requirements/base.in
-django==5.2.12
+django==5.2.13
     # via
     #   -r backend/requirements/base.in
     #   dj-database-url
     #   django-authtools
+    #   django-error-mail-dedup
     #   django-extensions
     #   django-import-export
     #   django-linear-migrations
@@ -26,6 +27,8 @@ django==5.2.12
 django-admin-list-filter-dropdown==1.0.3
     # via -r backend/requirements/base.in
 django-authtools @ git+https://github.com/adRn-s/django-authtools@a3284c976719bd26f085fdac9951009acda804dc
+    # via -r backend/requirements/base.in
+django-error-mail-dedup @ git+https://github.com/adRn-s/django-error-mail-dedup@2e9be2bb1056ca6ed7a5dc606af38e3c9d594482
     # via -r backend/requirements/base.in
 django-extensions==4.1
     # via -r backend/requirements/base.in

--- a/backend/requirements/3.11/dev.txt
+++ b/backend/requirements/3.11/dev.txt
@@ -20,9 +20,9 @@ attrs==26.1.0
     #   -c backend/requirements/3.11/base.txt
     #   jsonschema
     #   referencing
-boto3==1.42.83
+boto3==1.42.86
     # via -r backend/requirements/dev.in
-botocore==1.42.83
+botocore==1.42.86
     # via
     #   boto3
     #   s3transfer
@@ -41,7 +41,7 @@ colorama==0.4.6 ; sys_platform == 'win32'
     #   tqdm
 contourpy==1.3.3
     # via matplotlib
-cryptography==46.0.6
+cryptography==46.0.7
     # via
     #   django-cryptography-django5
     #   django-sql-explorer
@@ -65,7 +65,7 @@ dj-database-url==3.1.2
     # via
     #   -c backend/requirements/3.11/base.txt
     #   -r backend/requirements/base.in
-django==5.2.12
+django==5.2.13
     # via
     #   -c backend/requirements/3.11/base.txt
     #   -r backend/requirements/base.in
@@ -75,6 +75,7 @@ django==5.2.12
     #   django-cors-headers
     #   django-cryptography-django5
     #   django-debug-toolbar
+    #   django-error-mail-dedup
     #   django-extensions
     #   django-import-export
     #   django-linear-migrations
@@ -100,6 +101,10 @@ django-cryptography-django5==2.2
     # via django-sql-explorer
 django-debug-toolbar==6.3.0
     # via -r backend/requirements/dev.in
+django-error-mail-dedup @ git+https://github.com/adRn-s/django-error-mail-dedup@2e9be2bb1056ca6ed7a5dc606af38e3c9d594482
+    # via
+    #   -c backend/requirements/3.11/base.txt
+    #   -r backend/requirements/base.in
 django-extensions==4.1
     # via
     #   -c backend/requirements/3.11/base.txt
@@ -223,7 +228,7 @@ numpy==2.4.4 ; python_full_version >= '3.12'
     #   contourpy
     #   matplotlib
     #   pandas
-openai==2.30.0
+openai==2.31.0
     # via -r backend/requirements/dev.in
 openpyxl==3.1.5
     # via

--- a/backend/requirements/3.11/testing.txt
+++ b/backend/requirements/3.11/testing.txt
@@ -27,11 +27,11 @@ attrs==26.1.0
     #   -c backend/requirements/3.11/dev.txt
     #   jsonschema
     #   referencing
-boto3==1.42.83
+boto3==1.42.86
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   -r backend/requirements/dev.in
-botocore==1.42.83
+botocore==1.42.86
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   boto3
@@ -62,7 +62,7 @@ contourpy==1.3.3
     #   matplotlib
 coverage==7.13.5
     # via pytest-cov
-cryptography==46.0.6
+cryptography==46.0.7
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   django-cryptography-django5
@@ -92,7 +92,7 @@ dj-database-url==3.1.2
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   -r backend/requirements/base.in
-django==5.2.12
+django==5.2.13
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   -r backend/requirements/base.in
@@ -102,6 +102,7 @@ django==5.2.12
     #   django-cors-headers
     #   django-cryptography-django5
     #   django-debug-toolbar
+    #   django-error-mail-dedup
     #   django-extensions
     #   django-import-export
     #   django-linear-migrations
@@ -135,6 +136,10 @@ django-debug-toolbar==6.3.0
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   -r backend/requirements/dev.in
+django-error-mail-dedup @ git+https://github.com/adRn-s/django-error-mail-dedup@2e9be2bb1056ca6ed7a5dc606af38e3c9d594482
+    # via
+    #   -c backend/requirements/3.11/dev.txt
+    #   -r backend/requirements/base.in
 django-extensions==4.1
     # via
     #   -c backend/requirements/3.11/dev.txt
@@ -195,7 +200,7 @@ fpdf2==2.8.7
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   -r backend/requirements/base.in
-greenlet==3.3.2
+greenlet==3.4.0
     # via playwright
 gunicorn==25.3.0
     # via
@@ -304,7 +309,7 @@ numpy==2.4.4 ; python_full_version >= '3.12'
     #   contourpy
     #   matplotlib
     #   pandas
-openai==2.30.0
+openai==2.31.0
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   -r backend/requirements/dev.in
@@ -388,7 +393,7 @@ pyparsing==3.3.2
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   matplotlib
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   pytest-base-url
     #   pytest-cov

--- a/backend/requirements/3.12/base.txt
+++ b/backend/requirements/3.12/base.txt
@@ -12,11 +12,12 @@ diff-match-patch==20241021
     # via django-import-export
 dj-database-url==3.1.2
     # via -r backend/requirements/base.in
-django==5.2.12
+django==5.2.13
     # via
     #   -r backend/requirements/base.in
     #   dj-database-url
     #   django-authtools
+    #   django-error-mail-dedup
     #   django-extensions
     #   django-import-export
     #   django-linear-migrations
@@ -26,6 +27,8 @@ django==5.2.12
 django-admin-list-filter-dropdown==1.0.3
     # via -r backend/requirements/base.in
 django-authtools @ git+https://github.com/adRn-s/django-authtools@a3284c976719bd26f085fdac9951009acda804dc
+    # via -r backend/requirements/base.in
+django-error-mail-dedup @ git+https://github.com/adRn-s/django-error-mail-dedup@2e9be2bb1056ca6ed7a5dc606af38e3c9d594482
     # via -r backend/requirements/base.in
 django-extensions==4.1
     # via -r backend/requirements/base.in

--- a/backend/requirements/3.12/dev.txt
+++ b/backend/requirements/3.12/dev.txt
@@ -20,9 +20,9 @@ attrs==26.1.0
     #   -c backend/requirements/3.12/base.txt
     #   jsonschema
     #   referencing
-boto3==1.42.83
+boto3==1.42.86
     # via -r backend/requirements/dev.in
-botocore==1.42.83
+botocore==1.42.86
     # via
     #   boto3
     #   s3transfer
@@ -41,7 +41,7 @@ colorama==0.4.6 ; sys_platform == 'win32'
     #   tqdm
 contourpy==1.3.3
     # via matplotlib
-cryptography==46.0.6
+cryptography==46.0.7
     # via
     #   django-cryptography-django5
     #   django-sql-explorer
@@ -65,7 +65,7 @@ dj-database-url==3.1.2
     # via
     #   -c backend/requirements/3.12/base.txt
     #   -r backend/requirements/base.in
-django==5.2.12
+django==5.2.13
     # via
     #   -c backend/requirements/3.12/base.txt
     #   -r backend/requirements/base.in
@@ -75,6 +75,7 @@ django==5.2.12
     #   django-cors-headers
     #   django-cryptography-django5
     #   django-debug-toolbar
+    #   django-error-mail-dedup
     #   django-extensions
     #   django-import-export
     #   django-linear-migrations
@@ -100,6 +101,10 @@ django-cryptography-django5==2.2
     # via django-sql-explorer
 django-debug-toolbar==6.3.0
     # via -r backend/requirements/dev.in
+django-error-mail-dedup @ git+https://github.com/adRn-s/django-error-mail-dedup@2e9be2bb1056ca6ed7a5dc606af38e3c9d594482
+    # via
+    #   -c backend/requirements/3.12/base.txt
+    #   -r backend/requirements/base.in
 django-extensions==4.1
     # via
     #   -c backend/requirements/3.12/base.txt
@@ -214,7 +219,7 @@ numpy==2.4.4
     #   contourpy
     #   matplotlib
     #   pandas
-openai==2.30.0
+openai==2.31.0
     # via -r backend/requirements/dev.in
 openpyxl==3.1.5
     # via

--- a/backend/requirements/3.12/testing.txt
+++ b/backend/requirements/3.12/testing.txt
@@ -27,11 +27,11 @@ attrs==26.1.0
     #   -c backend/requirements/3.12/dev.txt
     #   jsonschema
     #   referencing
-boto3==1.42.83
+boto3==1.42.86
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   -r backend/requirements/dev.in
-botocore==1.42.83
+botocore==1.42.86
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   boto3
@@ -62,7 +62,7 @@ contourpy==1.3.3
     #   matplotlib
 coverage==7.13.5
     # via pytest-cov
-cryptography==46.0.6
+cryptography==46.0.7
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   django-cryptography-django5
@@ -92,7 +92,7 @@ dj-database-url==3.1.2
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   -r backend/requirements/base.in
-django==5.2.12
+django==5.2.13
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   -r backend/requirements/base.in
@@ -102,6 +102,7 @@ django==5.2.12
     #   django-cors-headers
     #   django-cryptography-django5
     #   django-debug-toolbar
+    #   django-error-mail-dedup
     #   django-extensions
     #   django-import-export
     #   django-linear-migrations
@@ -135,6 +136,10 @@ django-debug-toolbar==6.3.0
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   -r backend/requirements/dev.in
+django-error-mail-dedup @ git+https://github.com/adRn-s/django-error-mail-dedup@2e9be2bb1056ca6ed7a5dc606af38e3c9d594482
+    # via
+    #   -c backend/requirements/3.12/dev.txt
+    #   -r backend/requirements/base.in
 django-extensions==4.1
     # via
     #   -c backend/requirements/3.12/dev.txt
@@ -195,7 +200,7 @@ fpdf2==2.8.7
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   -r backend/requirements/base.in
-greenlet==3.3.2
+greenlet==3.4.0
     # via playwright
 gunicorn==25.3.0
     # via
@@ -293,7 +298,7 @@ numpy==2.4.4
     #   contourpy
     #   matplotlib
     #   pandas
-openai==2.30.0
+openai==2.31.0
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   -r backend/requirements/dev.in
@@ -372,7 +377,7 @@ pyparsing==3.3.2
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   matplotlib
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   pytest-base-url
     #   pytest-cov

--- a/backend/requirements/3.13/base.txt
+++ b/backend/requirements/3.13/base.txt
@@ -12,11 +12,12 @@ diff-match-patch==20241021
     # via django-import-export
 dj-database-url==3.1.2
     # via -r backend/requirements/base.in
-django==5.2.12
+django==5.2.13
     # via
     #   -r backend/requirements/base.in
     #   dj-database-url
     #   django-authtools
+    #   django-error-mail-dedup
     #   django-extensions
     #   django-import-export
     #   django-linear-migrations
@@ -26,6 +27,8 @@ django==5.2.12
 django-admin-list-filter-dropdown==1.0.3
     # via -r backend/requirements/base.in
 django-authtools @ git+https://github.com/adRn-s/django-authtools@a3284c976719bd26f085fdac9951009acda804dc
+    # via -r backend/requirements/base.in
+django-error-mail-dedup @ git+https://github.com/adRn-s/django-error-mail-dedup@2e9be2bb1056ca6ed7a5dc606af38e3c9d594482
     # via -r backend/requirements/base.in
 django-extensions==4.1
     # via -r backend/requirements/base.in

--- a/backend/requirements/3.13/dev.txt
+++ b/backend/requirements/3.13/dev.txt
@@ -20,9 +20,9 @@ attrs==26.1.0
     #   -c backend/requirements/3.13/base.txt
     #   jsonschema
     #   referencing
-boto3==1.42.83
+boto3==1.42.86
     # via -r backend/requirements/dev.in
-botocore==1.42.83
+botocore==1.42.86
     # via
     #   boto3
     #   s3transfer
@@ -41,7 +41,7 @@ colorama==0.4.6 ; sys_platform == 'win32'
     #   tqdm
 contourpy==1.3.3
     # via matplotlib
-cryptography==46.0.6
+cryptography==46.0.7
     # via
     #   django-cryptography-django5
     #   django-sql-explorer
@@ -65,7 +65,7 @@ dj-database-url==3.1.2
     # via
     #   -c backend/requirements/3.13/base.txt
     #   -r backend/requirements/base.in
-django==5.2.12
+django==5.2.13
     # via
     #   -c backend/requirements/3.13/base.txt
     #   -r backend/requirements/base.in
@@ -75,6 +75,7 @@ django==5.2.12
     #   django-cors-headers
     #   django-cryptography-django5
     #   django-debug-toolbar
+    #   django-error-mail-dedup
     #   django-extensions
     #   django-import-export
     #   django-linear-migrations
@@ -100,6 +101,10 @@ django-cryptography-django5==2.2
     # via django-sql-explorer
 django-debug-toolbar==6.3.0
     # via -r backend/requirements/dev.in
+django-error-mail-dedup @ git+https://github.com/adRn-s/django-error-mail-dedup@2e9be2bb1056ca6ed7a5dc606af38e3c9d594482
+    # via
+    #   -c backend/requirements/3.13/base.txt
+    #   -r backend/requirements/base.in
 django-extensions==4.1
     # via
     #   -c backend/requirements/3.13/base.txt
@@ -214,7 +219,7 @@ numpy==2.4.4
     #   contourpy
     #   matplotlib
     #   pandas
-openai==2.30.0
+openai==2.31.0
     # via -r backend/requirements/dev.in
 openpyxl==3.1.5
     # via

--- a/backend/requirements/3.13/testing.txt
+++ b/backend/requirements/3.13/testing.txt
@@ -27,11 +27,11 @@ attrs==26.1.0
     #   -c backend/requirements/3.13/dev.txt
     #   jsonschema
     #   referencing
-boto3==1.42.83
+boto3==1.42.86
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   -r backend/requirements/dev.in
-botocore==1.42.83
+botocore==1.42.86
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   boto3
@@ -62,7 +62,7 @@ contourpy==1.3.3
     #   matplotlib
 coverage==7.13.5
     # via pytest-cov
-cryptography==46.0.6
+cryptography==46.0.7
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   django-cryptography-django5
@@ -92,7 +92,7 @@ dj-database-url==3.1.2
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   -r backend/requirements/base.in
-django==5.2.12
+django==5.2.13
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   -r backend/requirements/base.in
@@ -102,6 +102,7 @@ django==5.2.12
     #   django-cors-headers
     #   django-cryptography-django5
     #   django-debug-toolbar
+    #   django-error-mail-dedup
     #   django-extensions
     #   django-import-export
     #   django-linear-migrations
@@ -135,6 +136,10 @@ django-debug-toolbar==6.3.0
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   -r backend/requirements/dev.in
+django-error-mail-dedup @ git+https://github.com/adRn-s/django-error-mail-dedup@2e9be2bb1056ca6ed7a5dc606af38e3c9d594482
+    # via
+    #   -c backend/requirements/3.13/dev.txt
+    #   -r backend/requirements/base.in
 django-extensions==4.1
     # via
     #   -c backend/requirements/3.13/dev.txt
@@ -195,7 +200,7 @@ fpdf2==2.8.7
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   -r backend/requirements/base.in
-greenlet==3.3.2
+greenlet==3.4.0
     # via playwright
 gunicorn==25.3.0
     # via
@@ -293,7 +298,7 @@ numpy==2.4.4
     #   contourpy
     #   matplotlib
     #   pandas
-openai==2.30.0
+openai==2.31.0
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   -r backend/requirements/dev.in
@@ -372,7 +377,7 @@ pyparsing==3.3.2
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   matplotlib
-pytest==9.0.2
+pytest==9.0.3
     # via
     #   pytest-base-url
     #   pytest-cov

--- a/backend/requirements/base.in
+++ b/backend/requirements/base.in
@@ -1,6 +1,7 @@
 Django~=5.2  # remember to update pre-heat cache @ Dockerfile too
 backports-zoneinfo ; python_version < "3.9"  # hardcoded conditional to avoid issues on latest Py
 django-authtools @ git+https://github.com/adRn-s/django-authtools@dev_adRn
+django-error-mail-dedup @ git+https://github.com/adRn-s/django-error-mail-dedup@main
 djangorestframework
 drf-spectacular
 django-admin-list-filter-dropdown

--- a/backend/wui/settings/base.py
+++ b/backend/wui/settings/base.py
@@ -186,7 +186,17 @@ LOGGING = {
             "level": "ERROR",
             "filters": ["require_debug_false"],
             # 'class': 'django.utils.log.AdminEmailHandler'
-            "class": "common.logger.CustomAdminEmailHandler",
+            "class": "django_error_mail_dedup.handlers.DedupAdminEmailHandler",
+            "dedup_window_seconds": int(
+                os.environ.get("ERROR_EMAIL_DEDUP_WINDOW_SECONDS", "180"),
+            ),
+            "summary_email_every_seconds": int(
+                os.environ.get("ERROR_EMAIL_DEDUP_SUMMARY_EVERY_SECONDS", "60"),
+            ),
+            "state_file_path": os.environ.get(
+                "ERROR_EMAIL_DEDUP_STATE_FILE",
+                os.path.join(LOG_DIR, "error_email_dedup_state.json"),
+            ),
         },
         "console": {
             "level": "INFO",


### PR DESCRIPTION
replaces #276  (outsourcing the codebase to an extension for better development cycle)