### PR TITLE
Fix RO-Crate preview/PDF dropping name-only linked entities (#300)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,13 @@ db: schema load-postgres  ## Alias to: apply-migrations && load-postgres
 load-fixtures: apply-migrations
 	@docker compose exec parkour2-django python manage.py load_initial_data
 
+drop-db:  ## Drop all tables (public schema) from the running database
+	@docker compose exec parkour2-postgres sh -c \
+		'psql -q -U "$$POSTGRES_USER" -d "$$POSTGRES_DB" \
+		-c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"'
+
+reset-fixtures: drop-db load-fixtures  ## Drop DB then reload fixtures (for reusing running containers)
+
 load-backup: load-postgres load-media
 
 save-media:
@@ -288,13 +295,13 @@ playwright:  ## Run Frontend tests (reuse running container when available)
 	@if docker compose ps --status running --services | grep -q '^parkour2-django$$'; then \
 		if docker compose exec parkour2-django sh -lc 'command -v pytest > /dev/null && pytest --help | grep -q -- --browser && find /root/.cache/ms-playwright -path "*/firefox/firefox" -type f 2>/dev/null | grep -q .'; then \
 			echo "Info: Reusing running parkour2-django container for Playwright tests."; \
-			$(MAKE) e2e; \
+			$(MAKE) reset-fixtures e2e; \
 		else \
 			echo "Info: Testing runtime not ready in running container, installing testing requirements."; \
 			if docker compose exec parkour2-django sh -lc 'PY_VERSION=$$(python -c "import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")"); uv pip install -r requirements/$${PY_VERSION}/testing.txt && playwright install --with-deps firefox' \
 				&& docker compose exec parkour2-django sh -lc 'command -v pytest > /dev/null && pytest --help | grep -q -- --browser && find /root/.cache/ms-playwright -path "*/firefox/firefox" -type f 2>/dev/null | grep -q .'; then \
 				echo "Info: Testing dependencies installed, running Playwright tests."; \
-				$(MAKE) e2e; \
+				$(MAKE) reset-fixtures e2e; \
 			else \
 				echo "Info: Could not prepare running container for Playwright tests, redeploying stack first."; \
 				$(MAKE) down set-playwright deploy-webapp deploy-caddy collect-static load-fixtures; \

--- a/backend/frontend_testing_suite/tests/requests_page.py
+++ b/backend/frontend_testing_suite/tests/requests_page.py
@@ -390,10 +390,9 @@ def test_ro_crate_preview_opens_with_expected_api_params(page: Page):
     expect(preview_overlay.get_by_text("Library: Delivered library")).to_be_visible()
     expect(preview_overlay.get_by_text("Sample: Second sample")).to_be_visible()
     expect(preview_overlay.get_by_text("Barcode: 26L000501")).to_be_visible()
-    # NOTE: the organism linked to a library record is only rendered into the
-    # preview's per-record groups intermittently (a linked RO-Crate entity is
-    # sometimes dropped from the record grouping), so asserting on "Arabidopsis"
-    # here is flaky. Tracked separately from this dependency update.
+    # The organism linked to the library record must be rendered deterministically
+    # into the record's per-record groups (regression test for #300).
+    expect(preview_overlay.get_by_text("Organism: Arabidopsis")).to_be_visible()
     expect(
         preview_overlay.get_by_text("Library 1: Delivered library")
     ).not_to_be_visible()

--- a/backend/library/ro_crate.py
+++ b/backend/library/ro_crate.py
@@ -2687,11 +2687,21 @@ class ROCratePdfRenderer:
             entity, omit_relation_keys=omit_relation_keys
         )
         property_rows = [] if omit_property_rows else self.property_rows(entity, True)
-        return [
+        rows = [
             row
             for row in [*direct_rows, *property_rows, *relation_rows]
             if not self.is_hidden_row(row) and not self.is_low_value_preview_row(row)
         ]
+        # A linked term entity (e.g. an organism) may carry only a name, which is
+        # otherwise consumed by the section title. Surface it as a Name row so the
+        # section still renders instead of being dropped as empty by callers that
+        # skip sections without rows (matches the preview fix for #300).
+        if not rows:
+            name = entity.get(PDF_FIELD_NAME) or entity.get(PDF_FIELD_IDENTIFIER)
+            value = self.display_value(name)
+            if value not in (None, "", [], {}):
+                rows.append({"key": "Name", "value": value})
+        return rows
 
     def sequencing_sections(self, entity):
         sections = []

--- a/backend/library/tests.py
+++ b/backend/library/tests.py
@@ -1260,6 +1260,38 @@ class TestGenerateROCrateAPI(BaseAPITestCase):
         self.assertNotIn("Data Object Selected I7 Index", row_keys)
         self.assertNotIn("Data Object Selected I5 Index", row_keys)
 
+    def test_pdf_renders_name_only_linked_organism_section(self):
+        # Regression test for #300: a linked term entity that carries only a
+        # name (e.g. an organism) must still render its own section instead of
+        # being dropped as empty from a record's grouping.
+        renderer = self._pdf_renderer_for_graph(
+            [
+                {
+                    "@id": "#library-material-501",
+                    "@type": "Thing",
+                    "name": "Delivered library",
+                    "identifier": "26L000501",
+                    "organism": {"@id": "#organism-1"},
+                },
+                {"@id": "#organism-1", "@type": "Thing", "name": "Arabidopsis"},
+            ]
+        )
+
+        sections = renderer.related_model_sections(
+            renderer.entity_by_id("#library-material-501")
+        )
+
+        organism_sections = [
+            section
+            for section in sections
+            if section["title"] == "Organism: Arabidopsis"
+        ]
+        self.assertEqual(len(organism_sections), 1)
+        self.assertEqual(
+            organism_sections[0]["rows"],
+            [{"key": "Name", "value": "Arabidopsis"}],
+        )
+
     def test_pdf_model_display_rules_match_longest_prefix_first(self):
         renderer = self._pdf_renderer_for_graph([])
 

--- a/frontend/src/views/roCratePreviewView.vue
+++ b/frontend/src/views/roCratePreviewView.vue
@@ -1294,7 +1294,7 @@ export default {
           value: this.displayValue(value),
           wide: this.isWideValue(key, value)
         }));
-      return [
+      const rows = [
         ...directRows,
         ...(options.omitPropertyRows
           ? []
@@ -1302,8 +1302,22 @@ export default {
         ...this.relationRows(entity, options)
       ]
         .filter((row) => !this.isHiddenRow(row))
-        .filter((row) => !this.isLowValuePreviewRow(row))
-        .filter((row) => this.matchesSearch([row.key, row.value]));
+        .filter((row) => !this.isLowValuePreviewRow(row));
+      // A linked term entity (e.g. an organism) may carry only a name, which is
+      // otherwise consumed by the section title. Surface it as a Name row so the
+      // section still renders deterministically instead of being dropped as empty
+      // by callers that filter on `rows.length`.
+      if (!rows.length) {
+        const name = entity?.[fieldKeys.name] || entity?.[fieldKeys.identifier];
+        if (!this.isEmpty(name)) {
+          rows.push({
+            key: "Name",
+            value: this.displayValue(name),
+            wide: false
+          });
+        }
+      }
+      return rows.filter((row) => this.matchesSearch([row.key, row.value]));
     },
     shouldSkipNestedEntity(label, entity) {
       const normalizedLabel = this.normalizedDisplayKey(label);


### PR DESCRIPTION
Closes #300.

## Problem

In the RO-Crate export **preview**, a linked entity (observed with the library's **organism**) was only intermittently rendered into a record's per-record groups. The organism entity carries only a `name`, which is consumed by the section title, so `rowsForRelatedModelEntity` returned zero rows and both `relatedModelSections` and `buildRecord` dropped the section as empty. The `Organism: Arabidopsis` group was therefore missing from the preview.

The backend **PDF** renderer (`library/ro_crate.py`) is a faithful port of the same grouping logic and had the identical defect. The **ZIP** export embeds the raw RO-Crate `@graph` (the organism is always present there as a graph node) and is unaffected.

## Changes

- **Preview** (`frontend/src/views/roCratePreviewView.vue`): surface the entity's name as a fallback `Name` row in `rowsForRelatedModelEntity` when it would otherwise have none, so linked term sections render deterministically. Guarded to only trigger on otherwise-empty entities, so rich entities are unchanged.
- **PDF** (`backend/library/ro_crate.py`): same fallback in `rows_for_related_model_entity`, with a regression test (`test_pdf_renders_name_only_linked_organism_section`).
- **Test** (`backend/frontend_testing_suite/tests/requests_page.py`): restored the `Organism: Arabidopsis` assertion that was removed in #299, now deterministic.
- **Makefile**: reusing a running container (e.g. from `dev-ez`) left its existing data in place, so `load_initial_data` hit primary-key conflicts and the test admin user was absent, making every Playwright test fail at login. Added `drop-db` (drops/recreates the `public` schema) and `reset-fixtures` (`drop-db` + `load-fixtures`), run before `e2e` in both container-reuse branches of the `playwright` rule.

## Verification

- Restored preview assertion passes 3/3 serially (`test_ro_crate_preview_opens_with_expected_api_params`).
- New PDF regression test fails without the fix (`0 != 1`) and passes with it.
- `reset-fixtures` runs clean against a live reused container; login + target tests pass afterwards.