### PR TITLE
Fix Backend CI: pin setup-uv to v8.3.2

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -79,7 +79,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up UV for py ${{ matrix.python-version }}
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
           cache-dependency-glob: "backend/requirements/${{ matrix.python-version }}/*.txt"


### PR DESCRIPTION
The Backend workflow fails on every `build-and-test` matrix job at *Set up job*:

```
Unable to resolve action `astral-sh/setup-uv@v8`, unable to find version `v8`
```

`astral-sh/setup-uv` does not publish a floating `v8` major tag (only full versions like `v8.3.2`). This was introduced in ec18f3a4. `deps.yml` already pins the full `@v8.3.2`.

Note: the `gh-action-pins` auto-bump job won't self-heal this, since it only rewrites a ref when a strictly-greater major exists (latest is also major 8), so a manual pin is required.