### PR TITLE
Robustness fixes: unbounded request-editor sync poll, PI approval endpoint crash

### DIFF
--- a/backend/request/views.py
+++ b/backend/request/views.py
@@ -7,6 +7,7 @@ from io import StringIO
 from unicodedata import normalize
 from urllib.parse import urlencode
 
+from common.mviews import refresh_batched
 from common.serializers import UserSerializer
 from common.utils import retrieve_group_items
 from common.views import CsrfExemptSessionAuthentication, StandardResultsSetPagination
@@ -1123,22 +1124,26 @@ class ApproveViewSet(viewsets.ModelViewSet):
             if not all(s == 0 for s in instance.statuses):
                 raise ValueError(f"Not all statuses are zero: {instance.statuses}")
             if token == instance.token:
-                instance.libraries.all().update(status=1)
-                instance.samples.all().update(status=1)
-                instance.token = None
-                instance.approval = {
-                    "TIMESTAMP": dateformat.format(timezone.now(), "c"),
-                    "TOKEN": token,
-                    "REMOTE_ADDR": request.META["REMOTE_ADDR"],
-                    "REMOTE_PORT": request.META["REMOTE_PORT"],
-                    "HTTP_USER_AGENT": request.headers["user-agent"],
-                    "HTTP_ACCEPT": request.headers["accept"],
-                    "HTTP_ACCEPT_ENCODING": request.headers["accept-encoding"],
-                    "HTTP_ACCEPT_LANGUAGE": request.headers["accept-language"],
-                    "HTTP_X_FORWARDED_FOR": request.headers["x-forwarded-for"],
-                    "HTTP_X_REAL_IP": request.headers["x-real-ip"],
-                }
-                instance.save(update_fields=["token", "approval"])
+                library_ids = list(instance.libraries.values_list("id", flat=True))
+                sample_ids = list(instance.samples.values_list("id", flat=True))
+                with transaction.atomic():
+                    instance.libraries.all().update(status=1)
+                    instance.samples.all().update(status=1)
+                    instance.token = None
+                    instance.approval = {
+                        "TIMESTAMP": dateformat.format(timezone.now(), "c"),
+                        "TOKEN": token,
+                        "REMOTE_ADDR": request.META.get("REMOTE_ADDR"),
+                        "REMOTE_PORT": request.META.get("REMOTE_PORT"),
+                        "HTTP_USER_AGENT": request.headers.get("user-agent"),
+                        "HTTP_ACCEPT": request.headers.get("accept"),
+                        "HTTP_ACCEPT_ENCODING": request.headers.get("accept-encoding"),
+                        "HTTP_ACCEPT_LANGUAGE": request.headers.get("accept-language"),
+                        "HTTP_X_FORWARDED_FOR": request.headers.get("x-forwarded-for"),
+                        "HTTP_X_REAL_IP": request.headers.get("x-real-ip"),
+                    }
+                    instance.save(update_fields=["token", "approval"])
+                refresh_batched(library_ids=library_ids, sample_ids=sample_ids)
             else:
                 raise ValueError(f"Token mismatch.")
         except Exception as e:

--- a/frontend/src/views/librariesAndSamplesView.vue
+++ b/frontend/src/views/librariesAndSamplesView.vue
@@ -1552,6 +1552,7 @@ export default {
       roCratePreviewConfig: null,
       requestEditorSyncing: false,
       requestEditorSyncTimer: null,
+      requestEditorSyncAttempts: 0,
       pendingSavedRequestId: null,
       pendingSavedMode: null,
       paperlessApproval: false,
@@ -2394,6 +2395,7 @@ export default {
       }
       this.pendingSavedRequestId = requestId;
       this.requestEditorSyncing = true;
+      this.requestEditorSyncAttempts = 0;
 
       if (!this.pendingSavedRequestId) {
         this.getLibrariesSamples(1, false, true).finally(() => {
@@ -2402,14 +2404,21 @@ export default {
         return;
       }
 
+      // Bounded: give up after this many polls rather than retrying forever
+      // if the saved request never shows up (e.g. filtered out by date range,
+      // or the save silently failed to persist).
+      const maxAttempts = 30;
       const poll = async () => {
         if (this.loading || this.syncLoading) return;
+        this.requestEditorSyncAttempts += 1;
         await this.getLibrariesSamples(1, false, true);
         if (
           this.pendingSavedRequestId &&
           this.requestMetaById?.[this.pendingSavedRequestId]
         ) {
           this.finishRequestEditorSync();
+        } else if (this.requestEditorSyncAttempts >= maxAttempts) {
+          this.timeoutRequestEditorSync();
         }
       };
 
@@ -2426,6 +2435,7 @@ export default {
       }
       this.pendingSavedRequestId = null;
       this.pendingSavedMode = null;
+      this.requestEditorSyncAttempts = 0;
       this.requestEditorSyncing = false;
     },
     finishRequestEditorSync() {
@@ -2434,6 +2444,14 @@ export default {
           ? "Request updated successfully."
           : "Request created successfully.";
       showNotification(message, "success");
+      this.stopRequestEditorSync();
+      this.closeRequestEditorModal();
+    },
+    timeoutRequestEditorSync() {
+      showNotification(
+        "Request saved, but the list took too long to refresh. Reload the page to see it.",
+        "warning"
+      );
       this.stopRequestEditorSync();
       this.closeRequestEditorModal();
     },


### PR DESCRIPTION
## Summary

Two robustness fixes found during a first bare-metal deployment, each root-caused with a full writeup (available on request):

**1. Unbounded polling after saving a request** (`frontend/src/views/librariesAndSamplesView.vue`)

`startRequestEditorSync()` polls `/api/libraries_and_samples/` every 2s after a save, waiting for the saved request to appear in `requestMetaById`. There was no cap: if the request never appears (e.g. outside the current date filter, or a save that silently failed to persist), the poll ran forever, degrading the tab over many hours until it read as the app "hanging." Caps polling at 30 attempts (~60s) and surfaces a warning notification instead of polling indefinitely.

**2. PI approval endpoint crashes on missing WSGI/header keys, leaving a half-approved request** (`backend/request/views.py`, `ApproveViewSet.this`)

- `request.META["REMOTE_PORT"]` is indexed directly for an audit dict, but `REMOTE_PORT` isn't guaranteed by the WSGI spec — gunicorn's sync worker doesn't set it, so every approval click raised `KeyError: 'REMOTE_PORT'` and the linked page showed `{"success": false, "error": "'REMOTE_PORT'"}`.
- The status-flip (`libraries.all().update(...)` / `samples.all().update(...)`) ran before that line with no surrounding transaction, so the crash left libraries/samples already flipped to approved (status=1) in the DB while `token` was never cleared and `approval`/confirmation email never wrote — the link became permanently broken for that request (a second click hit a different error since the pre-condition `all statuses == 0` no longer held).
- Separately, `QuerySet.update()` bypasses the `post_save` signals that refresh `complete_library_data_mv`/`complete_sample_data_mv`, so even a successful run wouldn't update the Libraries & Samples list without an explicit refresh.

Fix: switch to `.get()` with defaults for the optional META/header fields, wrap the status flip + save in `transaction.atomic()`, and call `common.mviews.refresh_batched()` afterward so the UI list reflects the change immediately.

## Test plan

- [x] `git apply --check` / clean apply of the frontend patch against current `develop`
- [x] `python -m py_compile backend/request/views.py`
- [x] `ruff format` / `pyupgrade` / `django-upgrade` pre-commit hooks pass
- [ ] Manual: save a request with samples that fall outside the active date filter and confirm the tab shows the timeout warning instead of polling forever
- [ ] Manual: click a PI approval link on a deployment where gunicorn doesn't populate `REMOTE_PORT` and confirm it completes (status flip, token cleared, email sent, list updates)