### PR TITLE
Fix AVITI sample sheet filename; drop dev CORS via Vite proxy

### DIFF
--- a/backend/wui/settings/dev.py
+++ b/backend/wui/settings/dev.py
@@ -9,13 +9,11 @@ INSTALLED_APPS += [
     "schema_viewer",
     # "debug_toolbar",
     "django_migration_linter",
-    "corsheaders",
     # "explorer",
 ]
 
 MIDDLEWARE = [
     # "debug_toolbar.middleware.DebugToolbarMiddleware",
-    "corsheaders.middleware.CorsMiddleware",
     *MIDDLEWARE,
 ]
 
@@ -45,12 +43,6 @@ additional_ips = os.environ.get("DEBUG_TOOLBAR_INTERNAL_IPS")
 if additional_ips:
     INTERNAL_IPS.extend(ip.strip() for ip in additional_ips.split(","))
 
-
-# CORS settings to enable API calls for Vue.js while development
-CORS_ALLOW_CREDENTIALS = True
-CORS_ALLOWED_ORIGINS = [
-    "http://localhost:5174",
-]
 
 DEBUG_TOOLBAR_CONFIG = {
     "SHOW_TOOLBAR_CALLBACK": lambda _: True,

--- a/backend/wui/settings/testing.py
+++ b/backend/wui/settings/testing.py
@@ -19,19 +19,10 @@ NOTEBOOK_ARGUMENTS += [
 INSTALLED_APPS += [
     "schema_viewer",
     "django_migration_linter",
-    "corsheaders",
 ]
 
 MIDDLEWARE += [
-    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
-]
-
-
-# CORS settings to enable API calls for Vue.js while development
-CORS_ALLOW_CREDENTIALS = True
-CORS_ALLOWED_ORIGINS = [
-    "http://localhost:5174",
 ]
 
 MIGRATION_LINTER_OPTIONS = {

--- a/frontend/src/utilities/apiUtils.js
+++ b/frontend/src/utilities/apiUtils.js
@@ -64,12 +64,7 @@ export function handleError(error) {
 }
 
 export function urlStringStartsWith() {
-  let urlString = window.location.href.split("/vue/");
-  if (urlString[0] === "http://localhost:5174") {
-    return "http://localhost:9980";
-  } else {
-    return urlString[0];
-  }
+  return window.location.href.split("/vue/")[0];
 }
 
 export function createAxiosObject() {

--- a/frontend/src/views/loadFlowcellsView.vue
+++ b/frontend/src/views/loadFlowcellsView.vue
@@ -1396,10 +1396,14 @@ export default {
           },
           { responseType: "blob" }
         );
-        saveAs(
-          response.data,
-          `${selectedRows[0].flowcell_id || "flowcell"}_SampleSheet.csv`
-        );
+        const contentDisposition = response.headers["content-disposition"];
+        const match =
+          contentDisposition &&
+          contentDisposition.match(/filename="?([^"]+)"?/);
+        const filename = match
+          ? match[1]
+          : `${selectedRows[0].flowcell_id || "flowcell"}_SampleSheet.csv`;
+        saveAs(response.data, filename);
       } catch (error) {
         handleError(error);
       }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,11 +4,36 @@ import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import vueJsx from "@vitejs/plugin-vue-jsx";
 
+const backendTarget = process.env.VITE_BACKEND_URL || "http://localhost:9980";
+
+const backendPaths = [
+  "/api",
+  "/api-auth",
+  "/api_user_details",
+  "/admin",
+  "/media",
+  "/login",
+  "/logout",
+  "/get_navigation_tree",
+  "/password_reset",
+  "/danke",
+  "/openapi"
+];
+
 export default defineConfig({
   base: "/vue/",
   server: {
     host: true,
-    allowedHosts: true
+    allowedHosts: true,
+    proxy: Object.fromEntries(
+      backendPaths.map((path) => [
+        path,
+        {
+          target: backendTarget,
+          changeOrigin: true
+        }
+      ])
+    )
   },
   build: {
     assetsDir: "vue-assets"


### PR DESCRIPTION
## Summary
- The `download_sample_sheet` endpoint already set the correct `Content-Disposition` filename (`<flowcell_id>_RunManifest.csv` for AVITI, `<flowcell_id>_SampleSheet.csv` otherwise), but the frontend ignored that header and hardcoded `_SampleSheet.csv` when saving the blob. It now reads the filename from the response header, falling back to the old name if missing.
- Added a Vite dev-server proxy (`frontend/vite.config.js`) forwarding backend paths (`/api`, `/media`, `/login`, etc.) to the Django backend, so the frontend is same-origin with the API in development, matching production.
- Simplified `urlStringStartsWith()` accordingly, since the special-cased cross-origin backend URL is no longer needed.
- Removed `corsheaders` app/middleware and CORS settings from `dev.py`/`testing.py`, since same-origin requests no longer require CORS.

## Test plan
- [ ] Run `npm run dev` and confirm API calls succeed with the new proxy (no CORS errors in console)
- [ ] Download a sample sheet for an AVITI flowcell and confirm the saved file is named `<flowcell_id>_RunManifest.csv`
- [ ] Download a sample sheet for a non-AVITI flowcell and confirm it's still named `<flowcell_id>_SampleSheet.csv`
- [ ] Confirm login/logout and media downloads still work in dev through the proxy