### PR TITLE
Drop unused django-cors-headers; fix stale nginx-server.conf Vite port

### DIFF
--- a/backend/requirements/3.10/base.txt
+++ b/backend/requirements/3.10/base.txt
@@ -38,7 +38,7 @@ django-linear-migrations==2.19.0
     # via -r backend/requirements/base.in
 django-monthfield==0.1.4
     # via -r backend/requirements/base.in
-django-simple-history==3.12.0
+django-simple-history==3.13.0
     # via -r backend/requirements/base.in
 djangorestframework==3.17.1
     # via
@@ -76,7 +76,7 @@ packaging==26.2
     # via gunicorn
 pandas==2.3.3 ; python_full_version < '3.12'
     # via -r backend/requirements/base.in
-pandas==3.0.3 ; python_full_version >= '3.12'
+pandas==3.0.5 ; python_full_version >= '3.12'
     # via -r backend/requirements/base.in
 pillow==12.3.0
     # via fpdf2

--- a/backend/requirements/3.10/dev.txt
+++ b/backend/requirements/3.10/dev.txt
@@ -12,7 +12,6 @@ asgiref==3.12.1
     # via
     #   -c backend/requirements/3.10/base.txt
     #   django
-    #   django-cors-headers
 asttokens==3.0.2
     # via stack-data
 attrs==26.1.0
@@ -20,13 +19,13 @@ attrs==26.1.0
     #   -c backend/requirements/3.10/base.txt
     #   jsonschema
     #   referencing
-boto3==1.43.51
+boto3==1.43.54
     # via -r backend/requirements/dev.in
-botocore==1.43.51
+botocore==1.43.54
     # via
     #   boto3
     #   s3transfer
-certifi==2026.6.17
+certifi==2026.7.22
     # via
     #   httpcore
     #   httpx
@@ -74,7 +73,6 @@ django==5.2.16
     #   dj-database-url
     #   django-appconf
     #   django-authtools
-    #   django-cors-headers
     #   django-cryptography-django5
     #   django-debug-toolbar
     #   django-error-mail-dedup
@@ -97,8 +95,6 @@ django-authtools @ git+https://github.com/adRn-s/django-authtools@a3284c976719bd
     # via
     #   -c backend/requirements/3.10/base.txt
     #   -r backend/requirements/base.in
-django-cors-headers==4.9.0
-    # via -r backend/requirements/dev.in
 django-cryptography-django5==2.2
     # via django-sql-explorer
 django-debug-toolbar==7.0.0
@@ -127,7 +123,7 @@ django-monthfield==0.1.4
     #   -r backend/requirements/base.in
 django-schema-viewer==0.5.3
     # via -r backend/requirements/dev.in
-django-simple-history==3.12.0
+django-simple-history==3.13.0
     # via
     #   -c backend/requirements/3.10/base.txt
     #   -r backend/requirements/base.in
@@ -236,7 +232,7 @@ numpy==2.5.1 ; python_full_version >= '3.12'
     #   contourpy
     #   matplotlib
     #   pandas
-openai==2.46.0
+openai==2.47.0
     # via -r backend/requirements/dev.in
 openpyxl==3.1.5
     # via
@@ -252,7 +248,7 @@ pandas==2.3.3 ; python_full_version < '3.12'
     #   -c backend/requirements/3.10/base.txt
     #   -r backend/requirements/base.in
     #   -r backend/requirements/dev.in
-pandas==3.0.3 ; python_full_version >= '3.12'
+pandas==3.0.5 ; python_full_version >= '3.12'
     # via
     #   -c backend/requirements/3.10/base.txt
     #   -r backend/requirements/base.in
@@ -336,7 +332,7 @@ rpds-py==2026.6.3 ; python_full_version >= '3.11'
     #   -c backend/requirements/3.10/base.txt
     #   jsonschema
     #   referencing
-s3transfer==0.19.1
+s3transfer==0.19.2
     # via boto3
 six==1.17.0
     # via
@@ -346,7 +342,7 @@ sniffio==1.3.1
     # via openai
 sql-metadata==3.0.1
     # via -r backend/requirements/dev.in
-sqlglot==30.12.0
+sqlglot==30.13.0
     # via sql-metadata
 sqlparse==0.5.5
     # via

--- a/backend/requirements/3.10/testing.txt
+++ b/backend/requirements/3.10/testing.txt
@@ -17,7 +17,6 @@ asgiref==3.12.1
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   django
-    #   django-cors-headers
 asttokens==3.0.2
     # via
     #   -c backend/requirements/3.10/dev.txt
@@ -27,16 +26,16 @@ attrs==26.1.0
     #   -c backend/requirements/3.10/dev.txt
     #   jsonschema
     #   referencing
-boto3==1.43.51
+boto3==1.43.54
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   -r backend/requirements/dev.in
-botocore==1.43.51
+botocore==1.43.54
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   boto3
     #   s3transfer
-certifi==2026.6.17
+certifi==2026.7.22
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   httpcore
@@ -103,7 +102,6 @@ django==5.2.16
     #   dj-database-url
     #   django-appconf
     #   django-authtools
-    #   django-cors-headers
     #   django-cryptography-django5
     #   django-debug-toolbar
     #   django-error-mail-dedup
@@ -128,10 +126,6 @@ django-authtools @ git+https://github.com/adRn-s/django-authtools@a3284c976719bd
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   -r backend/requirements/base.in
-django-cors-headers==4.9.0
-    # via
-    #   -c backend/requirements/3.10/dev.txt
-    #   -r backend/requirements/dev.in
 django-cryptography-django5==2.2
     # via
     #   -c backend/requirements/3.10/dev.txt
@@ -168,7 +162,7 @@ django-schema-viewer==0.5.3
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   -r backend/requirements/dev.in
-django-simple-history==3.12.0
+django-simple-history==3.13.0
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   -r backend/requirements/base.in
@@ -210,7 +204,7 @@ fpdf2==2.8.7
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   -r backend/requirements/base.in
-greenlet==3.5.3
+greenlet==3.5.4
     # via playwright
 gunicorn==26.0.0
     # via
@@ -323,7 +317,7 @@ numpy==2.5.1 ; python_full_version >= '3.12'
     #   contourpy
     #   matplotlib
     #   pandas
-openai==2.46.0
+openai==2.47.0
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   -r backend/requirements/dev.in
@@ -342,7 +336,7 @@ pandas==2.3.3 ; python_full_version < '3.12'
     #   -c backend/requirements/3.10/dev.txt
     #   -r backend/requirements/base.in
     #   -r backend/requirements/dev.in
-pandas==3.0.3 ; python_full_version >= '3.12'
+pandas==3.0.5 ; python_full_version >= '3.12'
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   -r backend/requirements/base.in
@@ -483,7 +477,7 @@ rpds-py==2026.6.3 ; python_full_version >= '3.11'
     #   -c backend/requirements/3.10/dev.txt
     #   jsonschema
     #   referencing
-s3transfer==0.19.1
+s3transfer==0.19.2
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   boto3
@@ -499,7 +493,7 @@ sql-metadata==3.0.1
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   -r backend/requirements/dev.in
-sqlglot==30.12.0
+sqlglot==30.13.0
     # via
     #   -c backend/requirements/3.10/dev.txt
     #   sql-metadata

--- a/backend/requirements/3.11/base.txt
+++ b/backend/requirements/3.11/base.txt
@@ -38,7 +38,7 @@ django-linear-migrations==2.19.0
     # via -r backend/requirements/base.in
 django-monthfield==0.1.4
     # via -r backend/requirements/base.in
-django-simple-history==3.12.0
+django-simple-history==3.13.0
     # via -r backend/requirements/base.in
 djangorestframework==3.17.1
     # via
@@ -76,7 +76,7 @@ packaging==26.2
     # via gunicorn
 pandas==2.3.3 ; python_full_version < '3.12'
     # via -r backend/requirements/base.in
-pandas==3.0.3 ; python_full_version >= '3.12'
+pandas==3.0.5 ; python_full_version >= '3.12'
     # via -r backend/requirements/base.in
 pillow==12.3.0
     # via fpdf2

--- a/backend/requirements/3.11/dev.txt
+++ b/backend/requirements/3.11/dev.txt
@@ -12,7 +12,6 @@ asgiref==3.12.1
     # via
     #   -c backend/requirements/3.11/base.txt
     #   django
-    #   django-cors-headers
 asttokens==3.0.2
     # via stack-data
 attrs==26.1.0
@@ -20,13 +19,13 @@ attrs==26.1.0
     #   -c backend/requirements/3.11/base.txt
     #   jsonschema
     #   referencing
-boto3==1.43.51
+boto3==1.43.54
     # via -r backend/requirements/dev.in
-botocore==1.43.51
+botocore==1.43.54
     # via
     #   boto3
     #   s3transfer
-certifi==2026.6.17
+certifi==2026.7.22
     # via
     #   httpcore
     #   httpx
@@ -72,7 +71,6 @@ django==5.2.16
     #   dj-database-url
     #   django-appconf
     #   django-authtools
-    #   django-cors-headers
     #   django-cryptography-django5
     #   django-debug-toolbar
     #   django-error-mail-dedup
@@ -95,8 +93,6 @@ django-authtools @ git+https://github.com/adRn-s/django-authtools@a3284c976719bd
     # via
     #   -c backend/requirements/3.11/base.txt
     #   -r backend/requirements/base.in
-django-cors-headers==4.9.0
-    # via -r backend/requirements/dev.in
 django-cryptography-django5==2.2
     # via django-sql-explorer
 django-debug-toolbar==7.0.0
@@ -125,7 +121,7 @@ django-monthfield==0.1.4
     #   -r backend/requirements/base.in
 django-schema-viewer==0.5.3
     # via -r backend/requirements/dev.in
-django-simple-history==3.12.0
+django-simple-history==3.13.0
     # via
     #   -c backend/requirements/3.11/base.txt
     #   -r backend/requirements/base.in
@@ -226,7 +222,7 @@ numpy==2.5.1 ; python_full_version >= '3.12'
     #   contourpy
     #   matplotlib
     #   pandas
-openai==2.46.0
+openai==2.47.0
     # via -r backend/requirements/dev.in
 openpyxl==3.1.5
     # via
@@ -242,7 +238,7 @@ pandas==2.3.3 ; python_full_version < '3.12'
     #   -c backend/requirements/3.11/base.txt
     #   -r backend/requirements/base.in
     #   -r backend/requirements/dev.in
-pandas==3.0.3 ; python_full_version >= '3.12'
+pandas==3.0.5 ; python_full_version >= '3.12'
     # via
     #   -c backend/requirements/3.11/base.txt
     #   -r backend/requirements/base.in
@@ -321,7 +317,7 @@ rpds-py==2026.6.3
     #   -c backend/requirements/3.11/base.txt
     #   jsonschema
     #   referencing
-s3transfer==0.19.1
+s3transfer==0.19.2
     # via boto3
 six==1.17.0
     # via
@@ -331,7 +327,7 @@ sniffio==1.3.1
     # via openai
 sql-metadata==3.0.1
     # via -r backend/requirements/dev.in
-sqlglot==30.12.0
+sqlglot==30.13.0
     # via sql-metadata
 sqlparse==0.5.5
     # via

--- a/backend/requirements/3.11/testing.txt
+++ b/backend/requirements/3.11/testing.txt
@@ -17,7 +17,6 @@ asgiref==3.12.1
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   django
-    #   django-cors-headers
 asttokens==3.0.2
     # via
     #   -c backend/requirements/3.11/dev.txt
@@ -27,16 +26,16 @@ attrs==26.1.0
     #   -c backend/requirements/3.11/dev.txt
     #   jsonschema
     #   referencing
-boto3==1.43.51
+boto3==1.43.54
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   -r backend/requirements/dev.in
-botocore==1.43.51
+botocore==1.43.54
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   boto3
     #   s3transfer
-certifi==2026.6.17
+certifi==2026.7.22
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   httpcore
@@ -99,7 +98,6 @@ django==5.2.16
     #   dj-database-url
     #   django-appconf
     #   django-authtools
-    #   django-cors-headers
     #   django-cryptography-django5
     #   django-debug-toolbar
     #   django-error-mail-dedup
@@ -124,10 +122,6 @@ django-authtools @ git+https://github.com/adRn-s/django-authtools@a3284c976719bd
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   -r backend/requirements/base.in
-django-cors-headers==4.9.0
-    # via
-    #   -c backend/requirements/3.11/dev.txt
-    #   -r backend/requirements/dev.in
 django-cryptography-django5==2.2
     # via
     #   -c backend/requirements/3.11/dev.txt
@@ -164,7 +158,7 @@ django-schema-viewer==0.5.3
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   -r backend/requirements/dev.in
-django-simple-history==3.12.0
+django-simple-history==3.13.0
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   -r backend/requirements/base.in
@@ -200,7 +194,7 @@ fpdf2==2.8.7
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   -r backend/requirements/base.in
-greenlet==3.5.3
+greenlet==3.5.4
     # via playwright
 gunicorn==26.0.0
     # via
@@ -305,7 +299,7 @@ numpy==2.5.1 ; python_full_version >= '3.12'
     #   contourpy
     #   matplotlib
     #   pandas
-openai==2.46.0
+openai==2.47.0
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   -r backend/requirements/dev.in
@@ -324,7 +318,7 @@ pandas==2.3.3 ; python_full_version < '3.12'
     #   -c backend/requirements/3.11/dev.txt
     #   -r backend/requirements/base.in
     #   -r backend/requirements/dev.in
-pandas==3.0.3 ; python_full_version >= '3.12'
+pandas==3.0.5 ; python_full_version >= '3.12'
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   -r backend/requirements/base.in
@@ -460,7 +454,7 @@ rpds-py==2026.6.3
     #   -c backend/requirements/3.11/dev.txt
     #   jsonschema
     #   referencing
-s3transfer==0.19.1
+s3transfer==0.19.2
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   boto3
@@ -476,7 +470,7 @@ sql-metadata==3.0.1
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   -r backend/requirements/dev.in
-sqlglot==30.12.0
+sqlglot==30.13.0
     # via
     #   -c backend/requirements/3.11/dev.txt
     #   sql-metadata

--- a/backend/requirements/3.12/base.txt
+++ b/backend/requirements/3.12/base.txt
@@ -38,7 +38,7 @@ django-linear-migrations==2.19.0
     # via -r backend/requirements/base.in
 django-monthfield==0.1.4
     # via -r backend/requirements/base.in
-django-simple-history==3.12.0
+django-simple-history==3.13.0
     # via -r backend/requirements/base.in
 djangorestframework==3.17.1
     # via
@@ -70,7 +70,7 @@ openpyxl==3.1.5
     # via -r backend/requirements/base.in
 packaging==26.2
     # via gunicorn
-pandas==3.0.3
+pandas==3.0.5
     # via -r backend/requirements/base.in
 pillow==12.3.0
     # via fpdf2

--- a/backend/requirements/3.12/dev.txt
+++ b/backend/requirements/3.12/dev.txt
@@ -12,7 +12,6 @@ asgiref==3.12.1
     # via
     #   -c backend/requirements/3.12/base.txt
     #   django
-    #   django-cors-headers
 asttokens==3.0.2
     # via stack-data
 attrs==26.1.0
@@ -20,13 +19,13 @@ attrs==26.1.0
     #   -c backend/requirements/3.12/base.txt
     #   jsonschema
     #   referencing
-boto3==1.43.51
+boto3==1.43.54
     # via -r backend/requirements/dev.in
-botocore==1.43.51
+botocore==1.43.54
     # via
     #   boto3
     #   s3transfer
-certifi==2026.6.17
+certifi==2026.7.22
     # via
     #   httpcore
     #   httpx
@@ -72,7 +71,6 @@ django==5.2.16
     #   dj-database-url
     #   django-appconf
     #   django-authtools
-    #   django-cors-headers
     #   django-cryptography-django5
     #   django-debug-toolbar
     #   django-error-mail-dedup
@@ -95,8 +93,6 @@ django-authtools @ git+https://github.com/adRn-s/django-authtools@a3284c976719bd
     # via
     #   -c backend/requirements/3.12/base.txt
     #   -r backend/requirements/base.in
-django-cors-headers==4.9.0
-    # via -r backend/requirements/dev.in
 django-cryptography-django5==2.2
     # via django-sql-explorer
 django-debug-toolbar==7.0.0
@@ -125,7 +121,7 @@ django-monthfield==0.1.4
     #   -r backend/requirements/base.in
 django-schema-viewer==0.5.3
     # via -r backend/requirements/dev.in
-django-simple-history==3.12.0
+django-simple-history==3.13.0
     # via
     #   -c backend/requirements/3.12/base.txt
     #   -r backend/requirements/base.in
@@ -219,7 +215,7 @@ numpy==2.5.1
     #   contourpy
     #   matplotlib
     #   pandas
-openai==2.46.0
+openai==2.47.0
     # via -r backend/requirements/dev.in
 openpyxl==3.1.5
     # via
@@ -230,7 +226,7 @@ packaging==26.2
     #   -c backend/requirements/3.12/base.txt
     #   gunicorn
     #   matplotlib
-pandas==3.0.3
+pandas==3.0.5
     # via
     #   -c backend/requirements/3.12/base.txt
     #   -r backend/requirements/base.in
@@ -305,7 +301,7 @@ rpds-py==2026.6.3
     #   -c backend/requirements/3.12/base.txt
     #   jsonschema
     #   referencing
-s3transfer==0.19.1
+s3transfer==0.19.2
     # via boto3
 six==1.17.0
     # via
@@ -315,7 +311,7 @@ sniffio==1.3.1
     # via openai
 sql-metadata==3.0.1
     # via -r backend/requirements/dev.in
-sqlglot==30.12.0
+sqlglot==30.13.0
     # via sql-metadata
 sqlparse==0.5.5
     # via

--- a/backend/requirements/3.12/testing.txt
+++ b/backend/requirements/3.12/testing.txt
@@ -17,7 +17,6 @@ asgiref==3.12.1
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   django
-    #   django-cors-headers
 asttokens==3.0.2
     # via
     #   -c backend/requirements/3.12/dev.txt
@@ -27,16 +26,16 @@ attrs==26.1.0
     #   -c backend/requirements/3.12/dev.txt
     #   jsonschema
     #   referencing
-boto3==1.43.51
+boto3==1.43.54
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   -r backend/requirements/dev.in
-botocore==1.43.51
+botocore==1.43.54
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   boto3
     #   s3transfer
-certifi==2026.6.17
+certifi==2026.7.22
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   httpcore
@@ -99,7 +98,6 @@ django==5.2.16
     #   dj-database-url
     #   django-appconf
     #   django-authtools
-    #   django-cors-headers
     #   django-cryptography-django5
     #   django-debug-toolbar
     #   django-error-mail-dedup
@@ -124,10 +122,6 @@ django-authtools @ git+https://github.com/adRn-s/django-authtools@a3284c976719bd
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   -r backend/requirements/base.in
-django-cors-headers==4.9.0
-    # via
-    #   -c backend/requirements/3.12/dev.txt
-    #   -r backend/requirements/dev.in
 django-cryptography-django5==2.2
     # via
     #   -c backend/requirements/3.12/dev.txt
@@ -164,7 +158,7 @@ django-schema-viewer==0.5.3
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   -r backend/requirements/dev.in
-django-simple-history==3.12.0
+django-simple-history==3.13.0
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   -r backend/requirements/base.in
@@ -200,7 +194,7 @@ fpdf2==2.8.7
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   -r backend/requirements/base.in
-greenlet==3.5.3
+greenlet==3.5.4
     # via playwright
 gunicorn==26.0.0
     # via
@@ -298,7 +292,7 @@ numpy==2.5.1
     #   contourpy
     #   matplotlib
     #   pandas
-openai==2.46.0
+openai==2.47.0
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   -r backend/requirements/dev.in
@@ -312,7 +306,7 @@ packaging==26.2
     #   gunicorn
     #   matplotlib
     #   pytest
-pandas==3.0.3
+pandas==3.0.5
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   -r backend/requirements/base.in
@@ -444,7 +438,7 @@ rpds-py==2026.6.3
     #   -c backend/requirements/3.12/dev.txt
     #   jsonschema
     #   referencing
-s3transfer==0.19.1
+s3transfer==0.19.2
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   boto3
@@ -460,7 +454,7 @@ sql-metadata==3.0.1
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   -r backend/requirements/dev.in
-sqlglot==30.12.0
+sqlglot==30.13.0
     # via
     #   -c backend/requirements/3.12/dev.txt
     #   sql-metadata

--- a/backend/requirements/3.13/base.txt
+++ b/backend/requirements/3.13/base.txt
@@ -38,7 +38,7 @@ django-linear-migrations==2.19.0
     # via -r backend/requirements/base.in
 django-monthfield==0.1.4
     # via -r backend/requirements/base.in
-django-simple-history==3.12.0
+django-simple-history==3.13.0
     # via -r backend/requirements/base.in
 djangorestframework==3.17.1
     # via
@@ -70,7 +70,7 @@ openpyxl==3.1.5
     # via -r backend/requirements/base.in
 packaging==26.2
     # via gunicorn
-pandas==3.0.3
+pandas==3.0.5
     # via -r backend/requirements/base.in
 pillow==12.3.0
     # via fpdf2

--- a/backend/requirements/3.13/dev.txt
+++ b/backend/requirements/3.13/dev.txt
@@ -12,7 +12,6 @@ asgiref==3.12.1
     # via
     #   -c backend/requirements/3.13/base.txt
     #   django
-    #   django-cors-headers
 asttokens==3.0.2
     # via stack-data
 attrs==26.1.0
@@ -20,13 +19,13 @@ attrs==26.1.0
     #   -c backend/requirements/3.13/base.txt
     #   jsonschema
     #   referencing
-boto3==1.43.51
+boto3==1.43.54
     # via -r backend/requirements/dev.in
-botocore==1.43.51
+botocore==1.43.54
     # via
     #   boto3
     #   s3transfer
-certifi==2026.6.17
+certifi==2026.7.22
     # via
     #   httpcore
     #   httpx
@@ -72,7 +71,6 @@ django==5.2.16
     #   dj-database-url
     #   django-appconf
     #   django-authtools
-    #   django-cors-headers
     #   django-cryptography-django5
     #   django-debug-toolbar
     #   django-error-mail-dedup
@@ -95,8 +93,6 @@ django-authtools @ git+https://github.com/adRn-s/django-authtools@a3284c976719bd
     # via
     #   -c backend/requirements/3.13/base.txt
     #   -r backend/requirements/base.in
-django-cors-headers==4.9.0
-    # via -r backend/requirements/dev.in
 django-cryptography-django5==2.2
     # via django-sql-explorer
 django-debug-toolbar==7.0.0
@@ -125,7 +121,7 @@ django-monthfield==0.1.4
     #   -r backend/requirements/base.in
 django-schema-viewer==0.5.3
     # via -r backend/requirements/dev.in
-django-simple-history==3.12.0
+django-simple-history==3.13.0
     # via
     #   -c backend/requirements/3.13/base.txt
     #   -r backend/requirements/base.in
@@ -219,7 +215,7 @@ numpy==2.5.1
     #   contourpy
     #   matplotlib
     #   pandas
-openai==2.46.0
+openai==2.47.0
     # via -r backend/requirements/dev.in
 openpyxl==3.1.5
     # via
@@ -230,7 +226,7 @@ packaging==26.2
     #   -c backend/requirements/3.13/base.txt
     #   gunicorn
     #   matplotlib
-pandas==3.0.3
+pandas==3.0.5
     # via
     #   -c backend/requirements/3.13/base.txt
     #   -r backend/requirements/base.in
@@ -305,7 +301,7 @@ rpds-py==2026.6.3
     #   -c backend/requirements/3.13/base.txt
     #   jsonschema
     #   referencing
-s3transfer==0.19.1
+s3transfer==0.19.2
     # via boto3
 six==1.17.0
     # via
@@ -315,7 +311,7 @@ sniffio==1.3.1
     # via openai
 sql-metadata==3.0.1
     # via -r backend/requirements/dev.in
-sqlglot==30.12.0
+sqlglot==30.13.0
     # via sql-metadata
 sqlparse==0.5.5
     # via

--- a/backend/requirements/3.13/testing.txt
+++ b/backend/requirements/3.13/testing.txt
@@ -17,7 +17,6 @@ asgiref==3.12.1
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   django
-    #   django-cors-headers
 asttokens==3.0.2
     # via
     #   -c backend/requirements/3.13/dev.txt
@@ -27,16 +26,16 @@ attrs==26.1.0
     #   -c backend/requirements/3.13/dev.txt
     #   jsonschema
     #   referencing
-boto3==1.43.51
+boto3==1.43.54
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   -r backend/requirements/dev.in
-botocore==1.43.51
+botocore==1.43.54
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   boto3
     #   s3transfer
-certifi==2026.6.17
+certifi==2026.7.22
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   httpcore
@@ -99,7 +98,6 @@ django==5.2.16
     #   dj-database-url
     #   django-appconf
     #   django-authtools
-    #   django-cors-headers
     #   django-cryptography-django5
     #   django-debug-toolbar
     #   django-error-mail-dedup
@@ -124,10 +122,6 @@ django-authtools @ git+https://github.com/adRn-s/django-authtools@a3284c976719bd
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   -r backend/requirements/base.in
-django-cors-headers==4.9.0
-    # via
-    #   -c backend/requirements/3.13/dev.txt
-    #   -r backend/requirements/dev.in
 django-cryptography-django5==2.2
     # via
     #   -c backend/requirements/3.13/dev.txt
@@ -164,7 +158,7 @@ django-schema-viewer==0.5.3
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   -r backend/requirements/dev.in
-django-simple-history==3.12.0
+django-simple-history==3.13.0
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   -r backend/requirements/base.in
@@ -200,7 +194,7 @@ fpdf2==2.8.7
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   -r backend/requirements/base.in
-greenlet==3.5.3
+greenlet==3.5.4
     # via playwright
 gunicorn==26.0.0
     # via
@@ -298,7 +292,7 @@ numpy==2.5.1
     #   contourpy
     #   matplotlib
     #   pandas
-openai==2.46.0
+openai==2.47.0
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   -r backend/requirements/dev.in
@@ -312,7 +306,7 @@ packaging==26.2
     #   gunicorn
     #   matplotlib
     #   pytest
-pandas==3.0.3
+pandas==3.0.5
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   -r backend/requirements/base.in
@@ -444,7 +438,7 @@ rpds-py==2026.6.3
     #   -c backend/requirements/3.13/dev.txt
     #   jsonschema
     #   referencing
-s3transfer==0.19.1
+s3transfer==0.19.2
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   boto3
@@ -460,7 +454,7 @@ sql-metadata==3.0.1
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   -r backend/requirements/dev.in
-sqlglot==30.12.0
+sqlglot==30.13.0
     # via
     #   -c backend/requirements/3.13/dev.txt
     #   sql-metadata

--- a/backend/requirements/dev.in
+++ b/backend/requirements/dev.in
@@ -7,7 +7,6 @@ Werkzeug
 rich
 django-migration-linter
 django-schema-viewer
-django-cors-headers
 django-sql-explorer
 openai
 sql_metadata

--- a/misc/nginx-server.conf
+++ b/misc/nginx-server.conf
@@ -1,5 +1,5 @@
 upstream frontend {
-	server parkour2-vite:5173;
+	server parkour2-vite:5174;
 }
 
 upstream backend {


### PR DESCRIPTION
## Summary
Follow-up to #311, which removed all CORS usage now that the frontend is same-origin via the Vite dev proxy:
- Removed `django-cors-headers` from `backend/requirements/dev.in` (no longer referenced anywhere) and recompiled all lockfiles with `make compile`.
- Fixed `misc/nginx-server.conf`: the tracked `upstream frontend` pointed at `parkour2-vite:5173`, but `frontend/package.json`'s `start-dev` script (used by dev/testing containers) binds `5174`. Confirmed on `parkour-test`'s live nginx config, which already runs the corrected `5174` — the tracked file had just drifted from that manual fix.

Note: `make compile` runs with `--upgrade`, so the requirements diffs include a few unrelated minor version bumps (e.g. `pandas`, `django-simple-history`) picked up incidentally.

## Test plan
- [ ] `pip install -r backend/requirements/<version>/dev.txt` installs cleanly without `django-cors-headers`
- [ ] Confirm dev/testing containers still start and serve `/vue/` correctly with `corsheaders` absent