### PR TITLE
RO-Crate FEX delivery: per-record error isolation + internal_pis endpoint

### DIFF
--- a/backend/library/ro_crate.py
+++ b/backend/library/ro_crate.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import math
 import mimetypes
 import os
@@ -33,6 +34,8 @@ LibraryPreparation = apps.get_model("library_preparation", "LibraryPreparation")
 Flowcell = apps.get_model("flowcell", "Flowcell")
 IndexPool = apps.get_model("index_generator", "Pool")
 IndexPair = apps.get_model("library_sample_shared", "IndexPair")
+
+logger = logging.getLogger(__name__)
 
 RO_CRATE_VERSION = "1.1"
 RO_CRATE_SPEC_URI = f"https://w3id.org/ro/crate/{RO_CRATE_VERSION}"
@@ -797,6 +800,19 @@ class SimpleROCrateBuilder:
     def _has_part(self, entity_id):
         self.has_part_refs.append(_ref(entity_id))
 
+    def _record_checkpoint(self):
+        return (len(self.graph), len(self.root_refs), len(self.has_part_refs))
+
+    def _rollback_to_checkpoint(self, checkpoint):
+        graph_length, root_refs_length, has_part_length = checkpoint
+        for entity in self.graph[graph_length:]:
+            entity_id = entity.get("@id")
+            if self.entities.get(entity_id) is entity:
+                del self.entities[entity_id]
+        del self.graph[graph_length:]
+        del self.root_refs[root_refs_length:]
+        del self.has_part_refs[has_part_length:]
+
     def _add_property_values(self, owner, property_name, values, section):
         owner_id = owner.get("@id")
         if not owner_id:
@@ -1073,207 +1089,231 @@ class SimpleROCrateBuilder:
 
     def _add_sample_entities(self):
         for row in self.selection.sample_rows:
-            model = self.sample_models.get(row.sample_id)
-            source_id = f"#source-sample-{row.sample_id}"
-            sample_id = f"#sample-material-{row.sample_id}"
-            process_id = f"#sample-process-{row.sample_id}"
-            data_id = f"#sample-data-{row.sample_id}"
-            assay_id = f"#sample-assay-{row.sample_id}"
-
-            self._add(
-                {
-                    "@id": source_id,
-                    "@type": "Thing",
-                    "name": f"Source for {row.name}",
-                    "identifier": _parkour_identifier("source-sample", row.sample_id),
-                    "additionalType": [_ref(ISA_MATERIAL_URI)],
-                    "comments": _comments_from_mapping(
-                        {"source_request_identifier": row.request_name}, "samples"
-                    ),
-                },
-                "samples",
-            )
-
-            comments = []
-            if model:
-                comments.extend(
-                    _comments_from_mapping(
-                        _extract_model_fields(model, "sample_db_"), "samples"
-                    )
+            checkpoint = self._record_checkpoint()
+            try:
+                self._add_sample_entity(row)
+            except Exception:
+                logger.exception(
+                    "RO-Crate export: failed to build sample entity for barcode %s",
+                    row.barcode,
                 )
-                comments.extend(
-                    _comments_from_mapping(
-                        _record_property_metadata(model, "sample_db_"), "samples"
-                    )
+                self._rollback_to_checkpoint(checkpoint)
+                self.selection.skipped_records.append(
+                    f"{row.barcode}: metadata build failed"
                 )
-            sample_mv_comments = _comments_from_mapping(
-                _extract_model_fields(
-                    row,
-                    "sample_mv_",
-                    include_hidden_fields={"create_time"},
+
+    def _add_sample_entity(self, row):
+        model = self.sample_models.get(row.sample_id)
+        source_id = f"#source-sample-{row.sample_id}"
+        sample_id = f"#sample-material-{row.sample_id}"
+        process_id = f"#sample-process-{row.sample_id}"
+        data_id = f"#sample-data-{row.sample_id}"
+        assay_id = f"#sample-assay-{row.sample_id}"
+
+        self._add(
+            {
+                "@id": source_id,
+                "@type": "Thing",
+                "name": f"Source for {row.name}",
+                "identifier": _parkour_identifier("source-sample", row.sample_id),
+                "additionalType": [_ref(ISA_MATERIAL_URI)],
+                "comments": _comments_from_mapping(
+                    {"source_request_identifier": row.request_name}, "samples"
                 ),
-                "samples",
-            )
-            prep = self.library_preparations.get(row.sample_id)
-            if prep:
-                comments.extend(
-                    _comments_from_mapping(
-                        _extract_model_fields(prep, "library_preparation_"),
-                        "library_preparation",
-                    )
-                )
-            pooling = self.pooling_by_sample.get(row.sample_id)
-            if pooling:
-                comments.extend(
-                    _comments_from_mapping(
-                        _extract_model_fields(pooling, "pooling_"), "pooling"
-                    )
-                )
+            },
+            "samples",
+        )
 
-            sample = self._add(
-                {
-                    "@id": sample_id,
-                    "@type": "Thing",
-                    "name": row.name,
-                    "identifier": row.barcode,
-                    "additionalType": [
-                        _ref(ISA_MATERIAL_URI),
-                        _ref(ISA_SAMPLE_URI),
-                        _ref("https://bioschemas.org/Sample"),
-                    ],
-                    "derivedFrom": [_ref(source_id)],
-                    "comments": comments,
-                },
-                "samples",
+        comments = []
+        if model:
+            comments.extend(
+                _comments_from_mapping(
+                    _extract_model_fields(model, "sample_db_"), "samples"
+                )
             )
-            self._add_property_values(sample, "additionalProperty", comments, "samples")
-            self._link_biology_terms(sample, model)
-            self._link_index_metadata(sample, model, row, "samples")
-            pool_refs = self._index_pool_refs(model)
-            if pool_refs:
-                sample["associatedPool"] = pool_refs
+            comments.extend(
+                _comments_from_mapping(
+                    _record_property_metadata(model, "sample_db_"), "samples"
+                )
+            )
+        sample_mv_comments = _comments_from_mapping(
+            _extract_model_fields(
+                row,
+                "sample_mv_",
+                include_hidden_fields={"create_time"},
+            ),
+            "samples",
+        )
+        prep = self.library_preparations.get(row.sample_id)
+        if prep:
+            comments.extend(
+                _comments_from_mapping(
+                    _extract_model_fields(prep, "library_preparation_"),
+                    "library_preparation",
+                )
+            )
+        pooling = self.pooling_by_sample.get(row.sample_id)
+        if pooling:
+            comments.extend(
+                _comments_from_mapping(
+                    _extract_model_fields(pooling, "pooling_"), "pooling"
+                )
+            )
 
-            self._add_process(
-                process_id,
-                f"Sample metadata capture for {row.name}",
-                "sample-process",
-                row.sample_id,
-                [_ref(source_id)],
-                [_ref(sample_id), _ref(data_id)],
-                model,
-                "samples",
-                comments=sample_mv_comments,
-                parameter_values=sample_mv_comments,
-            )
-            self._add_data(
-                data_id,
-                f"Sample export metadata for {row.name}",
-                "sample-data",
-                row.sample_id,
-                "samples",
-            )
-            self._add_assay(
-                assay_id,
-                f"Assay for sample {row.name}",
-                sample_id,
-                process_id,
-                data_id,
-                "samples",
-            )
-            record_entity_ids = [source_id, sample_id, process_id, data_id, assay_id]
-            self._link_to_record_requests(
-                sample, model, row.request_id, record_entity_ids
-            )
+        sample = self._add(
+            {
+                "@id": sample_id,
+                "@type": "Thing",
+                "name": row.name,
+                "identifier": row.barcode,
+                "additionalType": [
+                    _ref(ISA_MATERIAL_URI),
+                    _ref(ISA_SAMPLE_URI),
+                    _ref("https://bioschemas.org/Sample"),
+                ],
+                "derivedFrom": [_ref(source_id)],
+                "comments": comments,
+            },
+            "samples",
+        )
+        self._add_property_values(sample, "additionalProperty", comments, "samples")
+        self._link_biology_terms(sample, model)
+        self._link_index_metadata(sample, model, row, "samples")
+        pool_refs = self._index_pool_refs(model)
+        if pool_refs:
+            sample["associatedPool"] = pool_refs
+
+        self._add_process(
+            process_id,
+            f"Sample metadata capture for {row.name}",
+            "sample-process",
+            row.sample_id,
+            [_ref(source_id)],
+            [_ref(sample_id), _ref(data_id)],
+            model,
+            "samples",
+            comments=sample_mv_comments,
+            parameter_values=sample_mv_comments,
+        )
+        self._add_data(
+            data_id,
+            f"Sample export metadata for {row.name}",
+            "sample-data",
+            row.sample_id,
+            "samples",
+        )
+        self._add_assay(
+            assay_id,
+            f"Assay for sample {row.name}",
+            sample_id,
+            process_id,
+            data_id,
+            "samples",
+        )
+        record_entity_ids = [source_id, sample_id, process_id, data_id, assay_id]
+        self._link_to_record_requests(sample, model, row.request_id, record_entity_ids)
 
     def _add_library_entities(self):
         for row in self.selection.library_rows:
-            model = self.library_models.get(row.library_id)
-            library_id = f"#library-material-{row.library_id}"
-            process_id = f"#library-process-{row.library_id}"
-            data_id = f"#library-data-{row.library_id}"
-            assay_id = f"#library-assay-{row.library_id}"
-
-            comments = []
-            if model:
-                comments.extend(
-                    _comments_from_mapping(
-                        _extract_model_fields(model, "library_db_"), "libraries"
-                    )
+            checkpoint = self._record_checkpoint()
+            try:
+                self._add_library_entity(row)
+            except Exception:
+                logger.exception(
+                    "RO-Crate export: failed to build library entity for barcode %s",
+                    row.barcode,
                 )
-                comments.extend(
-                    _comments_from_mapping(
-                        _record_property_metadata(model, "library_db_"), "libraries"
-                    )
-                )
-            pooling = self.pooling_by_library.get(row.library_id)
-            if pooling:
-                comments.extend(
-                    _comments_from_mapping(
-                        _extract_model_fields(pooling, "pooling_"), "pooling"
-                    )
+                self._rollback_to_checkpoint(checkpoint)
+                self.selection.skipped_records.append(
+                    f"{row.barcode}: metadata build failed"
                 )
 
-            library = self._add(
-                {
-                    "@id": library_id,
-                    "@type": "Thing",
-                    "name": row.name,
-                    "identifier": row.barcode,
-                    "additionalType": [_ref(ISA_MATERIAL_URI), _ref(ISA_LIBRARY_URI)],
-                    "comments": comments,
-                },
-                "libraries",
-            )
-            self._add_property_values(
-                library, "additionalProperty", comments, "libraries"
-            )
-            self._link_biology_terms(library, model)
-            self._link_index_metadata(library, model, row, "libraries")
-            pool_refs = self._index_pool_refs(model)
-            if pool_refs:
-                library["associatedPool"] = pool_refs
+    def _add_library_entity(self, row):
+        model = self.library_models.get(row.library_id)
+        library_id = f"#library-material-{row.library_id}"
+        process_id = f"#library-process-{row.library_id}"
+        data_id = f"#library-data-{row.library_id}"
+        assay_id = f"#library-assay-{row.library_id}"
 
-            library_mv_comments = _comments_from_mapping(
-                _extract_model_fields(
-                    row,
-                    "library_mv_",
-                    include_hidden_fields={"create_time"},
-                ),
-                "libraries",
+        comments = []
+        if model:
+            comments.extend(
+                _comments_from_mapping(
+                    _extract_model_fields(model, "library_db_"), "libraries"
+                )
             )
-            self._add_process(
-                process_id,
-                f"Library metadata capture for {row.name}",
-                "library-process",
-                row.library_id,
-                [_ref(library_id)],
-                [_ref(data_id)],
-                model,
-                "libraries",
-                comments=library_mv_comments,
-                parameter_values=library_mv_comments,
+            comments.extend(
+                _comments_from_mapping(
+                    _record_property_metadata(model, "library_db_"), "libraries"
+                )
             )
-            self._add_data(
-                data_id,
-                f"Library export metadata for {row.name}",
-                "library-data",
-                row.library_id,
-                "libraries",
+        pooling = self.pooling_by_library.get(row.library_id)
+        if pooling:
+            comments.extend(
+                _comments_from_mapping(
+                    _extract_model_fields(pooling, "pooling_"), "pooling"
+                )
             )
-            self._add_assay(
-                assay_id,
-                f"Assay for library {row.name}",
-                library_id,
-                process_id,
-                data_id,
-                "libraries",
-            )
-            self._link_to_record_requests(
-                library,
-                model,
-                row.request_id,
-                [library_id, process_id, data_id, assay_id],
-            )
+
+        library = self._add(
+            {
+                "@id": library_id,
+                "@type": "Thing",
+                "name": row.name,
+                "identifier": row.barcode,
+                "additionalType": [_ref(ISA_MATERIAL_URI), _ref(ISA_LIBRARY_URI)],
+                "comments": comments,
+            },
+            "libraries",
+        )
+        self._add_property_values(library, "additionalProperty", comments, "libraries")
+        self._link_biology_terms(library, model)
+        self._link_index_metadata(library, model, row, "libraries")
+        pool_refs = self._index_pool_refs(model)
+        if pool_refs:
+            library["associatedPool"] = pool_refs
+
+        library_mv_comments = _comments_from_mapping(
+            _extract_model_fields(
+                row,
+                "library_mv_",
+                include_hidden_fields={"create_time"},
+            ),
+            "libraries",
+        )
+        self._add_process(
+            process_id,
+            f"Library metadata capture for {row.name}",
+            "library-process",
+            row.library_id,
+            [_ref(library_id)],
+            [_ref(data_id)],
+            model,
+            "libraries",
+            comments=library_mv_comments,
+            parameter_values=library_mv_comments,
+        )
+        self._add_data(
+            data_id,
+            f"Library export metadata for {row.name}",
+            "library-data",
+            row.library_id,
+            "libraries",
+        )
+        self._add_assay(
+            assay_id,
+            f"Assay for library {row.name}",
+            library_id,
+            process_id,
+            data_id,
+            "libraries",
+        )
+        self._link_to_record_requests(
+            library,
+            model,
+            row.request_id,
+            [library_id, process_id, data_id, assay_id],
+        )
 
     def _add_process(
         self,

--- a/backend/library/tests.py
+++ b/backend/library/tests.py
@@ -1382,6 +1382,55 @@ class TestGenerateROCrateAPI(BaseAPITestCase):
 
     @patch("library.ro_crate.CompleteSampleData.objects")
     @patch("library.ro_crate.CompleteLibraryData.objects")
+    def test_sample_metadata_build_failure_is_isolated_and_recorded(
+        self, mock_library_objects, mock_sample_objects
+    ):
+        from library.ro_crate import SimpleROCrateBuilder
+
+        healthy_sample = create_sample("healthy-crate-sample", status=5)
+        broken_sample = create_sample("broken-crate-sample", status=5)
+        self.request.samples.add(healthy_sample, broken_sample)
+        self._set_ro_crate_complete_data_rows(
+            mock_library_objects,
+            mock_sample_objects,
+            samples=[
+                self._sample_view_row(healthy_sample),
+                self._sample_view_row(broken_sample),
+            ],
+        )
+
+        original_link_biology_terms = SimpleROCrateBuilder._link_biology_terms
+
+        def _link_biology_terms_side_effect(self, entity, model):
+            if model is not None and model.pk == broken_sample.pk:
+                raise ValueError("simulated metadata build failure")
+            return original_link_biology_terms(self, entity, model)
+
+        with patch.object(
+            SimpleROCrateBuilder,
+            "_link_biology_terms",
+            autospec=True,
+            side_effect=_link_biology_terms_side_effect,
+        ):
+            response = self.client.get(
+                reverse("generate-ro-crate-list"),
+                {
+                    "barcodes": (f"{healthy_sample.barcode},{broken_sample.barcode}"),
+                    "preview": "true",
+                },
+            )
+
+        payload = self._extract_preview_payload(response)
+        self.assertIn(
+            f"{broken_sample.barcode}: metadata build failed",
+            payload["skipped_records"],
+        )
+        graph_ids = self._graph_ids(payload["ro_crate"])
+        self.assertIn(f"#sample-material-{healthy_sample.pk}", graph_ids)
+        self.assertNotIn(f"#sample-material-{broken_sample.pk}", graph_ids)
+
+    @patch("library.ro_crate.CompleteSampleData.objects")
+    @patch("library.ro_crate.CompleteLibraryData.objects")
     def test_library_barcode_export_includes_library_relationships_and_hides_non_export_fields(
         self, mock_library_objects, mock_sample_objects
     ):

--- a/backend/usage/tests.py
+++ b/backend/usage/tests.py
@@ -1,3 +1,86 @@
-from django.test import TestCase
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework.test import APITestCase
 
-# Create your tests here.
+from common.models import Organization, PrincipalInvestigator
+
+User = get_user_model()
+
+
+class TestInternalPIsAPI(APITestCase):
+    def setUp(self):
+        self.staff_user = User.objects.create_user(
+            email="staff@test.io", password="foo-bar", is_staff=True
+        )
+        self.non_staff_user = User.objects.create_user(
+            email="nonstaff@test.io", password="foo-bar", is_staff=False
+        )
+        self.internal_org = Organization.objects.create(name="MPI-IE")
+        self.external_org = Organization.objects.create(name="External University")
+        PrincipalInvestigator.objects.create(
+            name="Cabezas-Wallscheid", organization=self.internal_org
+        )
+        PrincipalInvestigator.objects.create(
+            name="Manke", organization=self.internal_org
+        )
+        PrincipalInvestigator.objects.create(
+            name="Archived Internal PI",
+            organization=self.internal_org,
+            archived=True,
+        )
+        PrincipalInvestigator.objects.create(
+            name="External Collaborator", organization=self.external_org
+        )
+
+    def test_returns_lowercased_names_for_requested_organizations(self):
+        self.client.login(email="staff@test.io", password="foo-bar")
+        response = self.client.get(reverse("internal-pis"), {"organizations": "MPI-IE"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            sorted(response.data["pis"]),
+            ["cabezas-wallscheid", "manke"],
+        )
+
+    def test_excludes_archived_pis(self):
+        self.client.login(email="staff@test.io", password="foo-bar")
+        response = self.client.get(reverse("internal-pis"), {"organizations": "MPI-IE"})
+        self.assertNotIn("archived internal pi", response.data["pis"])
+
+    def test_excludes_pis_from_unlisted_organizations(self):
+        self.client.login(email="staff@test.io", password="foo-bar")
+        response = self.client.get(reverse("internal-pis"), {"organizations": "MPI-IE"})
+        self.assertNotIn("external collaborator", response.data["pis"])
+
+    def test_accepts_multiple_comma_separated_organizations(self):
+        self.client.login(email="staff@test.io", password="foo-bar")
+        response = self.client.get(
+            reverse("internal-pis"),
+            {"organizations": "MPI-IE,External University"},
+        )
+        self.assertEqual(
+            sorted(response.data["pis"]),
+            ["cabezas-wallscheid", "external collaborator", "manke"],
+        )
+
+    def test_unknown_organization_name_returns_empty_list(self):
+        self.client.login(email="staff@test.io", password="foo-bar")
+        response = self.client.get(
+            reverse("internal-pis"), {"organizations": "Nonexistent Org"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["pis"], [])
+
+    def test_missing_organizations_param_returns_400(self):
+        self.client.login(email="staff@test.io", password="foo-bar")
+        response = self.client.get(reverse("internal-pis"))
+        self.assertEqual(response.status_code, 400)
+
+    def test_empty_organizations_param_returns_400(self):
+        self.client.login(email="staff@test.io", password="foo-bar")
+        response = self.client.get(reverse("internal-pis"), {"organizations": ""})
+        self.assertEqual(response.status_code, 400)
+
+    def test_non_staff_user_is_forbidden(self):
+        self.client.login(email="nonstaff@test.io", password="foo-bar")
+        response = self.client.get(reverse("internal-pis"), {"organizations": "MPI-IE"})
+        self.assertEqual(response.status_code, 403)

--- a/backend/usage/views.py
+++ b/backend/usage/views.py
@@ -11,6 +11,7 @@ Request = apps.get_model("request", "Request")
 LibraryType = apps.get_model("library_sample_shared", "LibraryType")
 Library = apps.get_model("library", "Library")
 Sample = apps.get_model("sample", "Sample")
+PrincipalInvestigator = apps.get_model("common", "PrincipalInvestigator")
 
 
 def get_date_range(request, format):
@@ -226,3 +227,32 @@ class LibraryTypesUsage(APIView):
 
         data = sorted(data, key=lambda x: x["name"])
         return Response(data)
+
+
+class InternalPIsView(APIView):
+    permission_classes = (IsAdminUser,)
+
+    def get(self, request):
+        raw_organizations = request.query_params.get("organizations", "")
+        organization_names = [
+            name.strip() for name in raw_organizations.split(",") if name.strip()
+        ]
+        if not organization_names:
+            return Response(
+                {
+                    "error": (
+                        "Provide at least one comma separated organization name "
+                        "via the 'organizations' query parameter."
+                    )
+                },
+                status=400,
+            )
+
+        pi_names = (
+            PrincipalInvestigator.objects.filter(
+                archived=False, organization__name__in=organization_names
+            )
+            .values_list("name", flat=True)
+            .distinct()
+        )
+        return Response({"pis": sorted({name.lower() for name in pi_names})})

--- a/backend/wui/urls.py
+++ b/backend/wui/urls.py
@@ -9,6 +9,8 @@ from drf_spectacular.views import (
     SpectacularSwaggerView,
 )
 
+from usage.views import InternalPIsView
+
 from .api import router
 
 urlpatterns = [
@@ -16,6 +18,7 @@ urlpatterns = [
     #   url("accounts/", include("authtools.urls")),
     path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
     path("api/", include(router.urls)),
+    path("api/internal_pis/", InternalPIsView.as_view(), name="internal-pis"),
     path("api/usage/", include("usage.urls")),
     path("", include("common.urls")),
     path("", include("request.urls")),


### PR DESCRIPTION
## Summary
Parkour2 side of the RO-Crate FEX delivery feature (dissectBCL side to follow separately). See `docs/superpowers/specs/2026-07-28-ro-crate-fex-delivery-design.md` for the full design.

- Harden `SimpleROCrateBuilder` so a single malformed sample/library no longer 500s the whole `generate_ro_crate` export: each record is now built via `_add_sample_entity`/`_add_library_entity`, wrapped in try/except with checkpoint/rollback of any partially-added graph state, and recorded in `skipped_records` on failure instead of aborting.
- Add staff-only `GET /api/internal_pis/?organizations=<comma-separated names>`, returning the lowercased names of non-archived `PrincipalInvestigator`s in the given organization(s). This lets dissectBCL replace its static `Internals.PIs` config list with a Parkour-backed, organization-parameterized lookup — no schema changes required.

## Test plan
- [x] `library.tests.TestGenerateROCrateAPI` (18 tests, including new `test_sample_metadata_build_failure_is_isolated_and_recorded`)
- [x] `usage.tests.TestInternalPIsAPI` (8 new tests: multi-org, archived exclusion, unknown org, missing/empty param → 400, non-staff → 403)
- [x] Full project test suite (284 tests) green