### PR TITLE
Fix RO-Crate 1.1/ISA conformance: undefined context terms + non-Person authorship

### DIFF
--- a/backend/library/ro_crate.py
+++ b/backend/library/ro_crate.py
@@ -931,6 +931,37 @@ class SimpleROCrateBuilder:
             }
         )
 
+    def _add_person_entity(self, user):
+        if not user:
+            return None
+        person_id = f"#person-{user.pk}"
+        person = {
+            "@id": person_id,
+            "@type": "Person",
+            "name": user.full_name or user.email,
+            "givenName": user.first_name,
+            "familyName": user.last_name,
+            "email": user.email,
+            "identifier": _parkour_identifier("user", user.pk),
+        }
+        organization = getattr(user, "organization", None)
+        if organization:
+            org_id = f"#organization-{organization.pk}"
+            self._add(
+                {
+                    "@id": org_id,
+                    "@type": "Organization",
+                    "name": organization.name,
+                    "identifier": _parkour_identifier("organization", organization.pk),
+                },
+                "request",
+            )
+            self._mention(org_id)
+            person["affiliation"] = _ref(org_id)
+        self._add(person, "request")
+        self._mention(person_id)
+        return person_id
+
     def _add_root_dataset(self, root_request):
         is_multi = len(self.selection.target_request_ids) > 1
         root_name = (
@@ -953,6 +984,7 @@ class SimpleROCrateBuilder:
                 "request",
             )
         )
+        person_id = self._add_person_entity(getattr(root_request, "user", None))
         root = self._add(
             {
                 "@id": RO_CRATE_ROOT_ID,
@@ -979,7 +1011,8 @@ class SimpleROCrateBuilder:
                 "conformsTo": [_ref(RO_CRATE_SPEC_URI)],
                 "additionalType": [_ref(ISA_INVESTIGATION_URI), "Investigation"],
                 "license": _ref(RO_CRATE_LICENSE_ID),
-                "creator": _ref(PARKOUR_SOFTWARE_ID),
+                "creator": _ref(person_id) if person_id else _ref(PARKOUR_SOFTWARE_ID),
+                "author": _ref(person_id) if person_id else _ref(PARKOUR_SOFTWARE_ID),
                 "publisher": _ref(PARKOUR_ORGANIZATION_ID),
                 "comments": comments,
                 "mentions": [],

--- a/backend/library/ro_crate.py
+++ b/backend/library/ro_crate.py
@@ -1970,6 +1970,8 @@ class SimpleROCrateBuilder:
             "associatedPool": {"@id": "http://schema.org/isRelatedTo", "@type": "@id"},
             "sequencedOn": {"@id": "http://schema.org/isRelatedTo", "@type": "@id"},
             "requestContext": {"@id": "http://schema.org/isPartOf", "@type": "@id"},
+            "variableMeasured": "http://schema.org/variableMeasured",
+            "measurementMethod": "http://schema.org/measurementMethod",
         }
 
 

--- a/backend/library/tests.py
+++ b/backend/library/tests.py
@@ -1166,6 +1166,44 @@ class TestGenerateROCrateAPI(BaseAPITestCase):
 
     @patch("library.ro_crate.CompleteSampleData.objects")
     @patch("library.ro_crate.CompleteLibraryData.objects")
+    def test_context_defines_every_assay_term_for_valid_jsonld_compaction(
+        self, mock_library_objects, mock_sample_objects
+    ):
+        """
+        Assay entities set variableMeasured/measurementMethod (see
+        _add_assay); an RO-Crate 1.1 validator (rocrate-validator) flagged
+        these as undefined JSON-LD terms because the crate's own @context
+        (SimpleROCrateBuilder._context) didn't map them, which makes the
+        file descriptor invalid compacted JSON-LD per the RO-Crate spec.
+        """
+        library = create_library("context-crate-library", status=5)
+        self.request.libraries.add(library)
+        self._set_ro_crate_complete_data_rows(
+            mock_library_objects,
+            mock_sample_objects,
+            libraries=[self._library_view_row(library)],
+        )
+
+        response = self.client.get(
+            reverse("generate-ro-crate-list"),
+            {"barcodes": library.barcode, "preview": "true"},
+        )
+        payload = self._extract_preview_payload(response)
+        context = payload["ro_crate"]["@context"][1]
+
+        assay_id = f"#library-assay-{library.pk}"
+        assay_entry = self._graph_entry(payload["ro_crate"], assay_id)
+        for term in ("variableMeasured", "measurementMethod"):
+            self.assertIn(term, assay_entry)
+            self.assertIn(
+                term,
+                context,
+                f"'{term}' is used on Assay entities but missing from @context, "
+                "making the file descriptor invalid compacted JSON-LD.",
+            )
+
+    @patch("library.ro_crate.CompleteSampleData.objects")
+    @patch("library.ro_crate.CompleteLibraryData.objects")
     def test_pdf_mode_returns_pdf_attachment_and_disables_cache(
         self, mock_library_objects, mock_sample_objects
     ):

--- a/backend/library/tests.py
+++ b/backend/library/tests.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from django.core.files.base import ContentFile
 from request.models import FileRequest
 
+from common.models import Organization
 from common.tests import BaseAPITestCase, BaseTestCase
 from common.utils import get_random_name, timezone
 from django.contrib.auth import get_user_model
@@ -774,6 +775,9 @@ class TestGenerateROCrateAPI(BaseAPITestCase):
     ):
         """Exporting by request name should yield a structured RO-Crate."""
         self._set_ro_crate_complete_data_rows(mock_library_objects, mock_sample_objects)
+        organization = Organization.objects.create(name="Crate Institute")
+        self.user.organization = organization
+        self.user.save()
 
         response = self.client.get(
             reverse("generate-ro-crate-list"), {"requests": self.request.name}
@@ -813,7 +817,9 @@ class TestGenerateROCrateAPI(BaseAPITestCase):
             {"@id": f"#study-{self.request.id}"},
             dataset_entry.get("hasPart", []),
         )
-        self.assertEqual(dataset_entry.get("creator"), {"@id": "#parkour-software"})
+        person_id = f"#person-{self.user.id}"
+        self.assertEqual(dataset_entry.get("creator"), {"@id": person_id})
+        self.assertEqual(dataset_entry.get("author"), {"@id": person_id})
         self.assertEqual(
             dataset_entry.get("publisher"), {"@id": "#parkour-organization"}
         )
@@ -821,11 +827,18 @@ class TestGenerateROCrateAPI(BaseAPITestCase):
             "https://github.com/nfdi4plants/isa-ro-crate-profile/tree/release/profile",
             graph_ids,
         )
-        self.assertNotIn(f"#person-{self.user.id}", graph_ids)
+        person_entry = self._graph_entry(payload, person_id)
+        self.assertEqual(person_entry.get("@type"), "Person")
+        self.assertEqual(person_entry.get("name"), self.user.full_name)
+        self.assertEqual(person_entry.get("givenName"), self.user.first_name)
+        self.assertEqual(person_entry.get("familyName"), self.user.last_name)
+        self.assertEqual(person_entry.get("email"), self.user.email)
+        org_id = f"#organization-{organization.pk}"
+        self.assertEqual(person_entry.get("affiliation"), {"@id": org_id})
+        org_entry = self._graph_entry(payload, org_id)
+        self.assertEqual(org_entry.get("@type"), "Organization")
+        self.assertEqual(org_entry.get("name"), organization.name)
         self.assertNotIn("#role-request-submitter", graph_ids)
-        self.assertFalse(
-            any(str(entity_id).startswith("#organization-") for entity_id in graph_ids)
-        )
         self.assertFalse(
             any(
                 str(entity_id).startswith("#principal-investigator-")


### PR DESCRIPTION
## Summary
Follow-up from #314, prompted by validating a real exported crate against the official RO-Crate validator (`roc-validator` / `rocrate-validator` CLI, https://pypi.org/project/roc-validator/).

Two rounds of fixes, both confirmed against a real exported crate (real DB-backed library/sample/flowcell/pool/user/organization fixtures, not synthetic JSON):

**1. Undefined `@context` terms.** Assay entities (`_add_assay`) set `variableMeasured` and `measurementMethod`, but `SimpleROCrateBuilder._context()` didn't define either term. Per the RO-Crate 1.1 spec, every JSON-LD key used in the file descriptor must resolve via `@context` in compacted form.

**2. Authorship attributed to software instead of the requesting user.** The root Dataset's `creator`/`publisher` pointed at `#parkour-software` (a `SoftwareApplication`). The `isa-ro-crate` profile requires an Investigation's `creator` to be of type `Person`, and RO-Crate 1.1 recommends an `author` property. Root Dataset `creator`/`author` now point at a `Person` entity built from `Request.user` (name, givenName, familyName, email, and an `affiliation` Organization when the user has one set) — e.g. for a request named `4012_Lex_Guz`, the Person is Lex, the submitting user. The software's role stays correctly modeled via the existing `CreateAction`'s `agent`/`instrument`; `publisher` still points at the Parkour organization.

## Validation results

| Profile | Severity | Before any fix | After both fixes |
|---|---|---|---|
| `ro-crate-1.1` | REQUIRED | 37/38 | **38/38** |
| `ro-crate-1.1` | RECOMMENDED | untested | **23/24** (only "Organization SHOULD have a URL" remains — Parkour's `Organization` model has no URL field to source it from; not fabricating one) |
| `isa-ro-crate` (the profile Parkour's crates target, `NFDI4PLANTS_ISA_PROFILE_URI`) | REQUIRED | 122/123 | **123/123** |

## Test plan
- [x] New test `test_context_defines_every_assay_term_for_valid_jsonld_compaction`
- [x] `test_request_name_export_returns_zip_with_root_dataset_and_isa_profile` updated to assert the new Person/Organization entities and creator/author/affiliation links (previously asserted the opposite — no person entity — which just pinned prior behavior, not a deliberate policy)
- [x] Full `library` test suite (35 tests) green after each round
- [x] Re-validated real exported crates with `rocrate-validator` against `ro-crate-1.1` (REQUIRED + RECOMMENDED) and `isa-ro-crate` (REQUIRED) after each round