### PR TITLE
Add barcode-keyed fastq-data stub entities to RO-Crate export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Unreleased
 ==========
 
 - Add staff-only `GET /api/internal_pis/?organizations=<comma-separated names>`, returning the lowercased names of non-archived `PrincipalInvestigator`s in the given organization(s). This lets dissectBCL replace its static `Internals.PIs` config list with a Parkour-backed, organization-parameterized lookup — no schema changes required.
+- RO-Crate export: per-record error isolation (a failed sample/library no longer aborts the whole export), Person/Organization entities as creator/author, RO-Crate 1.1/ISA profile conformance fixes, and barcode-keyed `#fastq-data-{barcode}` stub entities so dissectBCL can attach the real fastq files at delivery time.
 - ...
 
 

--- a/backend/library/ro_crate.py
+++ b/backend/library/ro_crate.py
@@ -800,6 +800,27 @@ class SimpleROCrateBuilder:
     def _has_part(self, entity_id):
         self.has_part_refs.append(_ref(entity_id))
 
+    def _add_fastq_data_stub(self, owner, row, section):
+        fastq_data_id = f"#fastq-data-{row.barcode}"
+        self._add(
+            {
+                "@id": fastq_data_id,
+                "@type": "Dataset",
+                "name": f"Raw sequencing data for {row.name}",
+                "description": (
+                    "Raw fastq sequencing data, populated at data delivery "
+                    "time by dissectBCL."
+                ),
+                "identifier": _parkour_identifier("fastq-data", row.barcode),
+            },
+            section,
+        )
+        owner["hasPart"] = _unique_refs(
+            owner.get("hasPart", []) + [_ref(fastq_data_id)]
+        )
+        self._has_part(fastq_data_id)
+        return fastq_data_id
+
     def _record_checkpoint(self):
         return (len(self.graph), len(self.root_refs), len(self.has_part_refs))
 
@@ -1215,6 +1236,7 @@ class SimpleROCrateBuilder:
         pool_refs = self._index_pool_refs(model)
         if pool_refs:
             sample["associatedPool"] = pool_refs
+        self._add_fastq_data_stub(sample, row, "samples")
 
         self._add_process(
             process_id,
@@ -1305,6 +1327,7 @@ class SimpleROCrateBuilder:
         pool_refs = self._index_pool_refs(model)
         if pool_refs:
             library["associatedPool"] = pool_refs
+        self._add_fastq_data_stub(library, row, "libraries")
 
         library_mv_comments = _comments_from_mapping(
             _extract_model_fields(

--- a/backend/library/tests.py
+++ b/backend/library/tests.py
@@ -1075,6 +1075,52 @@ class TestGenerateROCrateAPI(BaseAPITestCase):
 
     @patch("library.ro_crate.CompleteSampleData.objects")
     @patch("library.ro_crate.CompleteLibraryData.objects")
+    def test_sample_and_library_entities_link_a_fastq_data_stub(
+        self, mock_library_objects, mock_sample_objects
+    ):
+        library = create_library("fastq-stub-library", status=5)
+        sample = create_sample("fastq-stub-sample", status=5)
+        self.request.libraries.add(library)
+        self.request.samples.add(sample)
+        self._set_ro_crate_complete_data_rows(
+            mock_library_objects,
+            mock_sample_objects,
+            libraries=[self._library_view_row(library)],
+            samples=[self._sample_view_row(sample)],
+        )
+
+        response = self.client.get(
+            reverse("generate-ro-crate-list"),
+            {
+                "barcodes": f"{library.barcode},{sample.barcode}",
+                "preview": "true",
+            },
+        )
+        payload = self._extract_preview_payload(response)
+        ro_crate = payload["ro_crate"]
+        graph_ids = self._graph_ids(ro_crate)
+
+        library_fastq_id = f"#fastq-data-{library.barcode}"
+        sample_fastq_id = f"#fastq-data-{sample.barcode}"
+        self.assertIn(library_fastq_id, graph_ids)
+        self.assertIn(sample_fastq_id, graph_ids)
+
+        library_fastq_entry = self._graph_entry(ro_crate, library_fastq_id)
+        self.assertEqual(library_fastq_entry.get("@type"), "Dataset")
+        self.assertNotIn("contentUrl", library_fastq_entry)
+
+        library_entry = self._graph_entry(ro_crate, f"#library-material-{library.pk}")
+        self.assertIn({"@id": library_fastq_id}, library_entry.get("hasPart", []))
+
+        sample_entry = self._graph_entry(ro_crate, f"#sample-material-{sample.pk}")
+        self.assertIn({"@id": sample_fastq_id}, sample_entry.get("hasPart", []))
+
+        root_entry = self._graph_entry(ro_crate, "./")
+        self.assertIn({"@id": library_fastq_id}, root_entry.get("hasPart", []))
+        self.assertIn({"@id": sample_fastq_id}, root_entry.get("hasPart", []))
+
+    @patch("library.ro_crate.CompleteSampleData.objects")
+    @patch("library.ro_crate.CompleteLibraryData.objects")
     def test_multi_request_export_creates_one_isa_study_per_request(
         self, mock_library_objects, mock_sample_objects
     ):


### PR DESCRIPTION
## Summary
New feature (not a conformance fix, so a separate PR from #315), building toward dissectBCL adding real fastq File entities to the shipped RO-Crate graph.

Each sample/library material entity now links to a `#fastq-data-{barcode}` `Dataset` stub via `hasPart` (also linked from the root Dataset's `hasPart`). Parkour's web backend has no filesystem access to the actual fastq files, so it can only declare that this data exists and where it belongs in the graph — not physical facts like paths or checksums. dissectBCL, which does have that access, will look up this exact, predictable id (computable directly from its `Sample_<barcode>` folder names) and attach real `File`/`MediaObject` entities to it as `hasPart` members, rather than reverse-engineering attachment points by scanning for `identifier == barcode` matches against Parkour's pk-keyed entity ids.

Design notes (also covered in review if useful context):
- `@id` is barcode-keyed, deliberately different from every other entity in the graph (which is keyed by Parkour's internal integer pk) — the barcode is the one stable, external handle dissectBCL actually has.
- `@type` is `Dataset`, not `File`/`MediaObject`, since one barcode can map to 2+ physical files (R1/R2, possibly per-lane splits).
- Lives inside the existing per-record try/except + checkpoint-rollback in `_add_sample_entity`/`_add_library_entity` (from #314/#315) — a failure building the stub is isolated exactly like every other part of the record, no new error handling needed.

## Test plan
- [x] New test `test_sample_and_library_entities_link_a_fastq_data_stub`
- [x] Full `library` test suite (36 tests) green
- [x] Re-validated a real exported crate with `rocrate-validator`: `ro-crate-1.1` and `isa-ro-crate` profiles both still pass 100% of REQUIRED checks (38/38, 123/123)