### PR TITLE
fix: add missing 400.html custom error template

### DIFF
--- a/backend/common/templates/400.html
+++ b/backend/common/templates/400.html
@@ -1,0 +1,27 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block css %}
+<style>
+    body {
+        background:
+            linear-gradient(rgba(5, 24, 28, 0.58), rgba(5, 24, 28, 0.58)),
+            url("{% static 'images/error-page-background.jpg' %}") no-repeat center center fixed;
+        background-size: cover;
+    }
+</style>
+{% endblock css %}
+
+{% block title %}Parkour LIMS | Bad Request{% endblock title %}
+
+{% block content %}
+<main class="error-page">
+    <section class="error-card">
+        <img class="error-logo" src="{% static 'images/parkour-logo.svg' %}" alt="">
+        <div class="error-code">400</div>
+        <h1>Bad request</h1>
+        <p>The server could not understand your request. Please check the URL and try again.</p>
+        <a class="django-button django-button-primary" href="{% url 'index' %}">Return home</a>
+    </section>
+</main>
+{% endblock content %}


### PR DESCRIPTION
## Summary

Django's [error-view customization checklist](https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/#customize-the-default-error-views) recommends styled `400.html`/`403.html`/`404.html`/`500.html` templates. We already had 403/404/500; 400 (bad request) was the only one missing. Added it following the exact same pattern (same CSS classes, background, logo, "Return home" button).

## Test plan

- [x] `manage.py validate_templates` — 0 errors
- [x] Directly rendered `400.html` via `render_to_string` — renders correctly
- [x] `make djtest` — 303 tests, `OK`