### PR TITLE
feat: add HTML preview to RO-Crate export zip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Unreleased
 - Add/Edit Request Index I7/I5 dropdowns: fixed wrong index pair shown for index kits where several `IndexType` positions share an identical sequence (e.g. single-fixed-i5 ATAC adapter lists) — label/editor lookup resolved by sequence, so duplicate sequences always displayed the first matching position regardless of the admin-defined `IndexPair`. Now disambiguated using the row's already-selected partner index.
 - Admin: fixed HTTP 400 "Max number of fields exceeded" when assigning a large `IndexI7`/`IndexI5` set to an `IndexType` or bulk-actioning a large `IndexI5`/`IndexI7` changelist — raised `DATA_UPLOAD_MAX_NUMBER_FIELDS`, switched `IndexType`'s index widgets to `autocomplete_fields`, and any remaining overflow now shows a friendly error instead of a blank 400.
 - Add/Edit Request: save confirmation now includes the request ID (e.g. "Request 42 updated successfully.").
+- RO-Crate export: zip now also includes an offline-browsable `ro-crate-preview.html`, rendered from the JSON-LD via `ro-crate-html-js`.
 - ...
 
 

--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -1,5 +1,10 @@
-ARG PyVersion=3.12  # to be repeated after FROM, docker syntax is at fault.
-FROM python:${PyVersion}-bookworm AS pk2_base
+## Node runtime + ro-crate-html-js CLI, built once here so the Python image below
+## can just copy the binaries in (no apt-installed Node in the Python image).
+FROM node:24-bullseye AS ro_crate_html_tool
+WORKDIR /opt/ro-crate-html-js
+RUN npm install ro-crate-html-js
+
+FROM python:3.12-bookworm AS pk2_base
 ARG PyVersion=3.12
 
 ENV \
@@ -29,6 +34,11 @@ RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 COPY --from=ghcr.io/astral-sh/uv:0.12.5 /uv /bin/uv
 
 WORKDIR /usr/src/app
+
+## Node binary + ro-crate-html-js CLI, copied from the ro_crate_html_tool stage above.
+COPY --from=ro_crate_html_tool /usr/local/bin/node /usr/local/bin/node
+COPY --from=ro_crate_html_tool /opt/ro-crate-html-js/node_modules /opt/ro-crate-html-js/node_modules
+ENV PATH="/opt/ro-crate-html-js/node_modules/.bin:${PATH}"
 
 ## Pre-heat the cache
 RUN --mount=type=cache,target=/root/.cache/uv \

--- a/backend/library/ro_crate.py
+++ b/backend/library/ro_crate.py
@@ -23,6 +23,7 @@ from fpdf.enums import XPos, YPos
 from rest_framework import viewsets
 from rest_framework.response import Response
 
+from .ro_crate_html import RO_CRATE_HTML_PREVIEW_NAME, generate_html_preview
 from .utils import get_accessible_requests
 
 Library = apps.get_model("library", "Library")
@@ -2963,6 +2964,7 @@ def _render_pdf(result, skipped_records):
 
 def _zip_response(result, skipped_records):
     pdf_bytes = _render_pdf(result, skipped_records)
+    html_bytes = generate_html_preview(result.ro_crate)
     buffer = BytesIO()
     with ZipFile(buffer, "w", compression=ZIP_DEFLATED) as zip_file:
         zip_file.writestr(
@@ -2970,6 +2972,8 @@ def _zip_response(result, skipped_records):
             json.dumps(result.ro_crate, indent=2, ensure_ascii=False),
         )
         zip_file.writestr(RO_CRATE_EMBEDDED_PDF_NAME, pdf_bytes)
+        if html_bytes is not None:
+            zip_file.writestr(RO_CRATE_HTML_PREVIEW_NAME, html_bytes)
         for archive_path, source_path in result.file_entries:
             try:
                 with open(source_path, "rb") as handle:

--- a/backend/library/ro_crate_html.py
+++ b/backend/library/ro_crate_html.py
@@ -1,0 +1,45 @@
+import json
+import logging
+import os
+import subprocess
+import tempfile
+
+logger = logging.getLogger(__name__)
+
+RO_CRATE_HTML_PREVIEW_NAME = "ro-crate-preview.html"
+ROCHTML_BINARY = "rochtml"
+
+
+def generate_html_preview(ro_crate_json):
+    """Render an offline HTML preview of an RO-Crate JSON-LD graph via the
+    `rochtml` CLI (ro-crate-html-js). Returns the HTML bytes, or None if
+    generation failed - callers should treat this as best-effort."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        metadata_path = os.path.join(tmp_dir, "ro-crate-metadata.json")
+        with open(metadata_path, "w", encoding="utf-8") as handle:
+            json.dump(ro_crate_json, handle, ensure_ascii=False)
+
+        try:
+            subprocess.run(
+                [ROCHTML_BINARY, metadata_path],
+                check=True,
+                capture_output=True,
+                timeout=30,
+            )
+        except subprocess.CalledProcessError as exc:
+            stderr = (exc.stderr or b"").decode("utf-8", errors="replace")
+            logger.warning(
+                "RO-Crate HTML preview generation failed: %s\n%s", exc, stderr
+            )
+            return None
+        except (OSError, subprocess.SubprocessError) as exc:
+            logger.warning("RO-Crate HTML preview generation failed: %s", exc)
+            return None
+
+        preview_path = os.path.join(tmp_dir, RO_CRATE_HTML_PREVIEW_NAME)
+        try:
+            with open(preview_path, "rb") as handle:
+                return handle.read()
+        except OSError as exc:
+            logger.warning("RO-Crate HTML preview file missing: %s", exc)
+            return None

--- a/backend/library/tests.py
+++ b/backend/library/tests.py
@@ -1,4 +1,6 @@
 import json
+import os
+import subprocess
 from io import BytesIO
 from zipfile import ZipFile
 from unittest.mock import Mock, patch
@@ -20,6 +22,7 @@ from library.ro_crate import (
     _ro_crate_archive_name,
     _ro_crate_pdf_name,
 )
+from library.ro_crate_html import RO_CRATE_HTML_PREVIEW_NAME, generate_html_preview
 from library.views import (
     SEQUENCING_STATUSES,
     apply_stage_data_visibility,
@@ -621,6 +624,45 @@ class TestLibraries(BaseTestCase):
         self.assertEqual(response.status_code, 404)
 
 
+class TestGenerateHtmlPreview(TestCase):
+    """Tests for the rochtml CLI wrapper used by the RO-Crate export."""
+
+    def setUp(self):
+        self.ro_crate_json = {"@context": [], "@graph": []}
+
+    @patch("library.ro_crate_html.subprocess.run")
+    def test_returns_html_bytes_produced_by_rochtml(self, mock_run):
+        def write_preview_file(args, **kwargs):
+            metadata_path = args[1]
+            preview_path = os.path.join(
+                os.path.dirname(metadata_path), RO_CRATE_HTML_PREVIEW_NAME
+            )
+            with open(preview_path, "w", encoding="utf-8") as handle:
+                handle.write("<html>preview</html>")
+            return Mock(returncode=0)
+
+        mock_run.side_effect = write_preview_file
+
+        result = generate_html_preview(self.ro_crate_json)
+        self.assertEqual(result, b"<html>preview</html>")
+
+    @patch("library.ro_crate_html.subprocess.run")
+    def test_returns_none_when_rochtml_binary_is_missing(self, mock_run):
+        mock_run.side_effect = FileNotFoundError("rochtml not found")
+
+        result = generate_html_preview(self.ro_crate_json)
+        self.assertIsNone(result)
+
+    @patch("library.ro_crate_html.subprocess.run")
+    def test_returns_none_when_rochtml_exits_non_zero(self, mock_run):
+        mock_run.side_effect = subprocess.CalledProcessError(
+            returncode=1, cmd=["rochtml"]
+        )
+
+        result = generate_html_preview(self.ro_crate_json)
+        self.assertIsNone(result)
+
+
 class TestGenerateROCrateAPI(BaseAPITestCase):
     """Tests for the RO-Crate export endpoint."""
 
@@ -975,11 +1017,55 @@ class TestGenerateROCrateAPI(BaseAPITestCase):
         )
         self.assertIn("#ro-crate-export-action", graph_ids)
 
+    @patch("library.ro_crate.generate_html_preview")
+    @patch("library.ro_crate.CompleteSampleData.objects")
+    @patch("library.ro_crate.CompleteLibraryData.objects")
+    def test_zip_export_includes_html_preview_when_generation_succeeds(
+        self, mock_library_objects, mock_sample_objects, mock_generate_html_preview
+    ):
+        """The zip should include the rochtml-rendered HTML preview."""
+        self._set_ro_crate_complete_data_rows(mock_library_objects, mock_sample_objects)
+        mock_generate_html_preview.return_value = b"<html>preview</html>"
+
+        response = self.client.get(
+            reverse("generate-ro-crate-list"), {"requests": self.request.name}
+        )
+        self.assertEqual(response.status_code, 200)
+        _, archive_names = self._extract_zip_payload(response)
+        self.assertIn("ro-crate-preview.html", archive_names)
+        with ZipFile(BytesIO(response.content), "r") as zip_file:
+            self.assertEqual(
+                zip_file.read("ro-crate-preview.html"), b"<html>preview</html>"
+            )
+        mock_generate_html_preview.assert_called_once()
+
+    @patch("library.ro_crate.generate_html_preview")
+    @patch("library.ro_crate.CompleteSampleData.objects")
+    @patch("library.ro_crate.CompleteLibraryData.objects")
+    def test_zip_export_omits_html_preview_when_generation_fails(
+        self, mock_library_objects, mock_sample_objects, mock_generate_html_preview
+    ):
+        """A failed rochtml run should not break the rest of the export."""
+        self._set_ro_crate_complete_data_rows(mock_library_objects, mock_sample_objects)
+        mock_generate_html_preview.return_value = None
+
+        response = self.client.get(
+            reverse("generate-ro-crate-list"), {"requests": self.request.name}
+        )
+        self.assertEqual(response.status_code, 200)
+        payload, archive_names = self._extract_zip_payload(response)
+        self.assertNotIn("ro-crate-preview.html", archive_names)
+        self.assertIn("ro-crate-metadata.json", archive_names)
+        self.assertIn("ro-crate-preview.pdf", archive_names)
+        self.assertIn("@graph", payload)
+
+    @patch("library.ro_crate.generate_html_preview")
     @patch("library.ro_crate.CompleteSampleData.objects")
     @patch("library.ro_crate.CompleteLibraryData.objects")
     def test_request_path_metadata_preserves_optional_md5_without_packaging_paths(
-        self, mock_library_objects, mock_sample_objects
+        self, mock_library_objects, mock_sample_objects, mock_generate_html_preview
     ):
+        mock_generate_html_preview.return_value = None
         self.request.filepaths = {
             "data": {
                 "path": "/data/project/huge.fastq.gz",


### PR DESCRIPTION
## Summary
- RO-Crate export zip now includes an offline-browsable `ro-crate-preview.html`, rendered from the JSON-LD via the `ro-crate-html-js` CLI (`rochtml`).
- `backend.Dockerfile` gains a dedicated `ro_crate_html_tool` Node build stage; only the resulting `node` binary + `node_modules` are copied into the Python backend image, so no Node runtime/apt install lands in the Python image itself.
- Generation is best-effort: a failed `rochtml` run is logged (with stderr) and skipped, without breaking the rest of the export.

## Test plan
- [x] `make djtest` — full backend suite (316/316) passes, including new tests for `generate_html_preview` (success/missing-binary/non-zero-exit) and the zip export (HTML included on success, gracefully omitted on failure).
- [x] Manually ran `rochtml` inside the built container against a sample crate to confirm it works end-to-end.
- [x] Rebuilt the backend image from a clean cache to confirm the new Docker stage builds correctly.